### PR TITLE
fix: ensure `paints` is array when serialize

### DIFF
--- a/plugin/src/main/serializer.ts
+++ b/plugin/src/main/serializer.ts
@@ -24,7 +24,7 @@ const toHex = (color: RGB): string => {
 };
 
 const serializePaints = (paints?: readonly Paint[]) => {
-  if (!paints) {
+  if (!paints || !Array.isArray(paints)) {
     return [];
   }
   return paints


### PR DESCRIPTION
Updated Figma today and it started failing on almost every node with “Error: not a function”.
After some debugging, I found that it fails in `serializePaints`, where it receives a non-array value. Adding this extra condition fixes the issue.
<img width="421" height="137" alt="image" src="https://github.com/user-attachments/assets/681e62ca-eb51-40ad-861f-45a7100ce2e2" />
