### PR TITLE
fix: get_node timeout

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": false
+}

--- a/plugin/src/main/code.ts
+++ b/plugin/src/main/code.ts
@@ -279,13 +279,16 @@ const handleRequest = async (
               format === "SVG"
                 ? { format: "SVG" }
                 : format === "PDF"
-                ? { format: "PDF" }
-                : format === "JPG"
-                ? { format: "JPG", constraint: { type: "SCALE", value: scale } }
-                : {
-                    format: "PNG",
-                    constraint: { type: "SCALE", value: scale },
-                  };
+                  ? { format: "PDF" }
+                  : format === "JPG"
+                    ? {
+                        format: "JPG",
+                        constraint: { type: "SCALE", value: scale },
+                      }
+                    : {
+                        format: "PNG",
+                        constraint: { type: "SCALE", value: scale },
+                      };
 
             const bytes = await node.exportAsync(settings);
             const base64 = figma.base64Encode(bytes);
@@ -335,6 +338,14 @@ figma.ui.onmessage = async (message) => {
 
   if (message.type === "server-request") {
     const response = await handleRequest(message.payload as ServerRequest);
-    figma.ui.postMessage(response);
+    try {
+      figma.ui.postMessage(response);
+    } catch (err) {
+      figma.ui.postMessage({
+        type: response.type,
+        requestId: response.requestId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
 };


### PR DESCRIPTION
All `get_node` (and other serialization-based) requests were timing out, even for simple designs. The bridge timeout kept increasing (at `30s`) but the requests never resolved. The timeout [was here](https://github.com/gethopp/figma-mcp-bridge/blob/ed6a9aed200b7959e9a5528b1409b4b9ad2efbff/server/src/bridge.ts#L93).

The root case was Figma's plugin API returns `figma.mixed` (a JavaScript Symbol) when a node property has mixed values. For example, a text node with multiple font sizes, or a frame where each corner has a different radius. Symbols cannot be cloned by the structured clone algorithm that postMessage uses, so `figma.ui.postMessage(response)` threw:
`Error: in postMessage: Cannot unwrap symbol` (visible inside Figma's dev tools).

Because this postMessage call had no error handling, the error became an unhandled promise rejection. No response was ever sent back over the WebSocket, so the bridge waited until its timeout expired silently.

Also added `.prettierrc` file to avoid random formatting diffs.

Closes #3 
