### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 
 <img src="https://raw.githubusercontent.com/gethopp/figma-mcp-bridge/main/logo.png" alt="Figma MCP Bridge" align="center" />
 
+[![Figma Bridge MCP server](https://glama.ai/mcp/servers/gethopp/figma-mcp-bridge/badges/card.svg)](https://glama.ai/mcp/servers/gethopp/figma-mcp-bridge)
+
 <br/>
 
 While other amazing Figma MCP servers like [Figma-Context-MCP](https://github.com/GLips/Figma-Context-MCP/) exist, one issues is the [API limiting](https://github.com/GLips/Figma-Context-MCP/issues/258) for free users.


### PR DESCRIPTION
This PR adds a badge for the [Figma MCP Bridge](https://glama.ai/mcp/servers/gethopp/figma-mcp-bridge) server listing in Glama MCP server directory.

[![Figma Bridge MCP server](https://glama.ai/mcp/servers/gethopp/figma-mcp-bridge/badges/card.svg)](https://glama.ai/mcp/servers/gethopp/figma-mcp-bridge)

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new badge to the README file.
  * Improved README formatting for better presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->