### PR TITLE
feat: support multiple Figma files connected simultaneously

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ The limit for free accounts is 6 requests per month, yes **per month**.
 
 Figma MCP Bridge is a solution to this problem. It is a plugin + MCP server that streams live Figma document data to AI tools without hitting Figma API rate limits, so its Figma MCP for the rest of us ✊
 
+It supports **multiple Figma files connected simultaneously**; open the plugin in each file and your AI agent can query any of them by `fileKey`. Single-file setups work exactly as before with no changes required.
+
 ## Demo
 
 [Watch a demo of building a UI in Cursor with Figma MCP Bridge](https://youtu.be/ouygIhFBx0g)
@@ -53,12 +55,15 @@ Download the plugin from the [latest release](https://github.com/gethopp/figma-m
 
 Open a Figma file, run the plugin, and start prompting your AI tool. The MCP server will automatically connect to the plugin.
 
+To work across multiple files, just open the plugin in each Figma file. The bridge keeps all connections active and your AI agent can target any of them by `fileKey`.
+
 If you want to know more about how it works, read the [How it works](#how-it-works) section.
 
 ## Available Tools
 
 | Tool | Description |
 |------|-------------|
+| `list_files` | List all connected Figma files (supports multi-file workflows) |
 | `get_document` | Get the current Figma page document tree |
 | `get_selection` | Get the currently selected nodes in Figma |
 | `get_node` | Get a specific Figma node by ID (colon format, e.g. `4029:12345`) |
@@ -68,6 +73,8 @@ If you want to know more about how it works, read the [How it works](#how-it-wor
 | `get_variable_defs` | Get all variable collections, modes, and values (design tokens) |
 | `get_screenshot` | Export nodes as PNG/SVG/JPG/PDF (base64-encoded) |
 | `save_screenshots` | Export and save screenshots directly to the local filesystem |
+
+All tools accept an optional `fileKey` parameter when multiple Figma files are connected. Use `list_files` to discover connected files and their keys.
 
 ## Local development
 
@@ -129,10 +136,10 @@ The Figma plugin is the user interface for the Figma MCP Bridge. You run this in
 
 ### 2. The MCP Server
 
-The MCP server is the core of the Figma MCP Bridge. As the Figma plugin connects with the MCP server via a WebSocket connection, the MCP server is responsible for:
-- Handling WebSocket connections from the Figma plugin
-- Forwarding tool calls to the Figma plugin
-- Routing responses back to the Figma plugin
+The MCP server is the core of the Figma MCP Bridge. It maintains a registry of WebSocket connections keyed by `fileKey`, so multiple Figma files can be connected simultaneously. The server is responsible for:
+- Handling WebSocket connections from one or more Figma plugin instances
+- Routing tool calls to the correct file based on `fileKey`
+- Forwarding responses back to the AI client
 - Handling leader election (as we can have only one WS connection to an MCP server at a time)
 
 

--- a/plugin/src/main/code.ts
+++ b/plugin/src/main/code.ts
@@ -28,11 +28,24 @@ type PluginResponse = {
   error?: string;
 };
 
+const getFileKey = (): string => {
+  // figma.fileKey is available for saved files; fall back to root name
+  try {
+    if (typeof figma.fileKey === "string" && figma.fileKey) {
+      return figma.fileKey;
+    }
+  } catch {
+    // fileKey may not be available in all contexts
+  }
+  return figma.root.name;
+};
+
 const sendStatus = () => {
   figma.ui.postMessage({
     type: "plugin-status",
     payload: {
       fileName: figma.root.name,
+      fileKey: getFileKey(),
       selectionCount: figma.currentPage.selection.length,
     },
   });

--- a/plugin/src/ui/App.tsx
+++ b/plugin/src/ui/App.tsx
@@ -31,15 +31,17 @@ type PluginResponse = {
 
 type PluginStatus = {
   fileName: string;
+  fileKey: string;
   selectionCount: number;
 };
 
-const WS_URL = "ws://localhost:1994/ws";
+const WS_BASE_URL = "ws://localhost:1994/ws";
 
 export default function App() {
   const [connected, setConnected] = useState(false);
   const [status, setStatus] = useState<PluginStatus>({
     fileName: "Unknown file",
+    fileKey: "",
     selectionCount: 0
   });
   const socketRef = useRef<WebSocket | null>(null);
@@ -76,13 +78,17 @@ export default function App() {
     };
   }, []);
 
+  // Connect/reconnect WebSocket when fileKey changes
   useEffect(() => {
+    if (!status.fileKey) return;
+
     const connect = () => {
       if (socketRef.current) {
         socketRef.current.close();
       }
 
-      const ws = new WebSocket(WS_URL);
+      const wsUrl = `${WS_BASE_URL}?fileKey=${encodeURIComponent(status.fileKey)}&fileName=${encodeURIComponent(status.fileName)}`;
+      const ws = new WebSocket(wsUrl);
       socketRef.current = ws;
 
       ws.onopen = () => {
@@ -115,12 +121,14 @@ export default function App() {
     return () => {
       if (reconnectTimer.current !== null) {
         window.clearTimeout(reconnectTimer.current);
+        reconnectTimer.current = null;
       }
       if (socketRef.current) {
         socketRef.current.close();
+        socketRef.current = null;
       }
     };
-  }, []);
+  }, [status.fileKey, status.fileName]);
 
 
 

--- a/server/src/bridge.ts
+++ b/server/src/bridge.ts
@@ -26,9 +26,16 @@ export class Bridge {
   }
 
   handleUpgrade(request: IncomingMessage, socket: Duplex, head: Buffer): void {
-    const url = new URL(request.url ?? "", "http://localhost");
-    const fileKey = url.searchParams.get("fileKey");
-    const fileName = url.searchParams.get("fileName") ?? "Unknown";
+    if (request.url == undefined) {
+      console.error("Plugin connected without url, rejecting");
+      socket.destroy();
+      return;
+    }
+
+    const url = new URL(request.url, "http://localhost");
+    const { fileKey, fileName = "Unknown" } = Object.fromEntries(
+      url.searchParams
+    );
 
     if (!fileKey) {
       console.error("Plugin connected without fileKey, rejecting");
@@ -41,7 +48,11 @@ export class Bridge {
     });
   }
 
-  private handleConnection(ws: WebSocket, fileKey: string, fileName: string): void {
+  private handleConnection(
+    ws: WebSocket,
+    fileKey: string,
+    fileName: string
+  ): void {
     // Replace existing connection for the same file
     const existing = this.connections.get(fileKey);
     if (existing) {
@@ -92,16 +103,19 @@ export class Bridge {
       const entry = this.connections.get(fileKey);
       if (!entry) {
         const available = this.listConnectedFiles();
-        const hint = available.length > 0
-          ? ` Connected files: ${available.map(f => `"${f.fileName}" (fileKey: ${f.fileKey})`).join(", ")}`
-          : " No files are currently connected.";
+        const hint =
+          available.length > 0
+            ? ` Connected files: ${available.map((f) => `"${f.fileName}" (fileKey: ${f.fileKey})`).join(", ")}`
+            : " No files are currently connected.";
         throw new Error(`No plugin connected for fileKey "${fileKey}".${hint}`);
       }
       return entry.ws;
     }
 
     if (this.connections.size === 0) {
-      throw new Error("No plugin connected. Open a Figma file and run the bridge plugin.");
+      throw new Error(
+        "No plugin connected. Open a Figma file and run the bridge plugin."
+      );
     }
 
     if (this.connections.size === 1) {
@@ -111,7 +125,7 @@ export class Bridge {
 
     const files = this.listConnectedFiles();
     throw new Error(
-      `Multiple files connected. Specify a fileKey to choose which file to query. Connected files: ${files.map(f => `"${f.fileName}" (fileKey: ${f.fileKey})`).join(", ")}. Use the list_files tool to see all connected files.`
+      `Multiple files connected. Specify a fileKey to choose which file to query. Connected files: ${files.map((f) => `"${f.fileName}" (fileKey: ${f.fileKey})`).join(", ")}. Use the list_files tool to see all connected files.`
     );
   }
 
@@ -122,7 +136,11 @@ export class Bridge {
     }));
   }
 
-  send(requestType: string, nodeIds?: string[], fileKey?: string): Promise<BridgeResponse> {
+  send(
+    requestType: string,
+    nodeIds?: string[],
+    fileKey?: string
+  ): Promise<BridgeResponse> {
     return this.sendWithParams(requestType, nodeIds, undefined, fileKey);
   }
 

--- a/server/src/bridge.ts
+++ b/server/src/bridge.ts
@@ -1,7 +1,7 @@
 import { WebSocketServer, WebSocket } from "ws";
 import type { IncomingMessage } from "node:http";
 import type { Duplex } from "node:stream";
-import type { BridgeRequest, BridgeResponse } from "./types.js";
+import type { BridgeRequest, BridgeResponse, ConnectedFile } from "./types.js";
 
 interface PendingRequest {
   resolve: (resp: BridgeResponse) => void;
@@ -9,9 +9,15 @@ interface PendingRequest {
   timeout: ReturnType<typeof setTimeout>;
 }
 
+interface ConnectionEntry {
+  ws: WebSocket;
+  fileKey: string;
+  fileName: string;
+}
+
 export class Bridge {
   private wss: WebSocketServer;
-  private conn: WebSocket | null = null;
+  private connections = new Map<string, ConnectionEntry>();
   private pending = new Map<string, PendingRequest>();
   private counter = 0;
 
@@ -20,17 +26,29 @@ export class Bridge {
   }
 
   handleUpgrade(request: IncomingMessage, socket: Duplex, head: Buffer): void {
+    const url = new URL(request.url ?? "", "http://localhost");
+    const fileKey = url.searchParams.get("fileKey");
+    const fileName = url.searchParams.get("fileName") ?? "Unknown";
+
+    if (!fileKey) {
+      console.error("Plugin connected without fileKey, rejecting");
+      socket.destroy();
+      return;
+    }
+
     this.wss.handleUpgrade(request, socket, head, (ws) => {
-      this.handleConnection(ws);
+      this.handleConnection(ws, fileKey, fileName);
     });
   }
 
-  private handleConnection(ws: WebSocket): void {
-    // Replace existing connection (same behavior as Go version)
-    if (this.conn) {
-      this.conn.close();
+  private handleConnection(ws: WebSocket, fileKey: string, fileName: string): void {
+    // Replace existing connection for the same file
+    const existing = this.connections.get(fileKey);
+    if (existing) {
+      existing.ws.close();
     }
-    this.conn = ws;
+    this.connections.set(fileKey, { ws, fileKey, fileName });
+    console.error(`Plugin connected: ${fileName} (${fileKey})`);
 
     ws.on("message", (data) => {
       try {
@@ -47,30 +65,83 @@ export class Bridge {
     });
 
     ws.on("close", () => {
-      if (this.conn === ws) {
-        this.conn = null;
+      const current = this.connections.get(fileKey);
+      if (current?.ws === ws) {
+        this.connections.delete(fileKey);
+        console.error(`Plugin disconnected: ${fileName} (${fileKey})`);
       }
     });
 
     ws.on("error", (err) => {
       console.error("WebSocket error:", err.message);
-      if (this.conn === ws) {
-        this.conn = null;
+      const current = this.connections.get(fileKey);
+      if (current?.ws === ws) {
+        this.connections.delete(fileKey);
       }
     });
   }
 
-  send(requestType: string, nodeIds?: string[]): Promise<BridgeResponse> {
-    return this.sendWithParams(requestType, nodeIds);
+  /**
+   * Resolve which connection to use.
+   * - If fileKey is provided, use that specific connection.
+   * - If only one file is connected and no fileKey given, use it (backward compat).
+   * - If multiple files connected and no fileKey, throw with a helpful message.
+   */
+  private resolveConnection(fileKey?: string): WebSocket {
+    if (fileKey) {
+      const entry = this.connections.get(fileKey);
+      if (!entry) {
+        const available = this.listConnectedFiles();
+        const hint = available.length > 0
+          ? ` Connected files: ${available.map(f => `"${f.fileName}" (fileKey: ${f.fileKey})`).join(", ")}`
+          : " No files are currently connected.";
+        throw new Error(`No plugin connected for fileKey "${fileKey}".${hint}`);
+      }
+      return entry.ws;
+    }
+
+    if (this.connections.size === 0) {
+      throw new Error("No plugin connected. Open a Figma file and run the bridge plugin.");
+    }
+
+    if (this.connections.size === 1) {
+      const entry = this.connections.values().next().value!;
+      return entry.ws;
+    }
+
+    const files = this.listConnectedFiles();
+    throw new Error(
+      `Multiple files connected. Specify a fileKey to choose which file to query. Connected files: ${files.map(f => `"${f.fileName}" (fileKey: ${f.fileKey})`).join(", ")}. Use the list_files tool to see all connected files.`
+    );
+  }
+
+  listConnectedFiles(): ConnectedFile[] {
+    return [...this.connections.values()].map((entry) => ({
+      fileKey: entry.fileKey,
+      fileName: entry.fileName,
+    }));
+  }
+
+  send(requestType: string, nodeIds?: string[], fileKey?: string): Promise<BridgeResponse> {
+    return this.sendWithParams(requestType, nodeIds, undefined, fileKey);
   }
 
   sendWithParams(
     requestType: string,
     nodeIds?: string[],
-    params?: Record<string, unknown>
+    params?: Record<string, unknown>,
+    fileKey?: string
   ): Promise<BridgeResponse> {
     return new Promise((resolve, reject) => {
-      if (!this.conn || this.conn.readyState !== WebSocket.OPEN) {
+      let conn: WebSocket;
+      try {
+        conn = this.resolveConnection(fileKey);
+      } catch (err) {
+        reject(err);
+        return;
+      }
+
+      if (conn.readyState !== WebSocket.OPEN) {
         reject(new Error("Plugin not connected"));
         return;
       }
@@ -94,7 +165,7 @@ export class Bridge {
 
       this.pending.set(requestId, { resolve, reject, timeout });
 
-      this.conn.send(JSON.stringify(request), (err) => {
+      conn.send(JSON.stringify(request), (err) => {
         if (err) {
           clearTimeout(timeout);
           this.pending.delete(requestId);
@@ -121,10 +192,10 @@ export class Bridge {
     }
     this.pending.clear();
 
-    if (this.conn) {
-      this.conn.close();
-      this.conn = null;
+    for (const [, entry] of this.connections) {
+      entry.ws.close();
     }
+    this.connections.clear();
     this.wss.close();
   }
 }

--- a/server/src/follower.ts
+++ b/server/src/follower.ts
@@ -1,4 +1,4 @@
-import type { BridgeResponse, RPCRequest, RPCResponse } from "./types.js";
+import type { BridgeResponse, ConnectedFile, RPCRequest, RPCResponse } from "./types.js";
 
 /**
  * Follower proxies MCP tool calls to the leader via HTTP /rpc.
@@ -8,19 +8,22 @@ export class Follower {
 
   send(
     requestType: string,
-    nodeIds?: string[]
+    nodeIds?: string[],
+    fileKey?: string
   ): Promise<BridgeResponse> {
-    return this.sendWithParams(requestType, nodeIds);
+    return this.sendWithParams(requestType, nodeIds, undefined, fileKey);
   }
 
   async sendWithParams(
     requestType: string,
     nodeIds?: string[],
-    params?: Record<string, unknown>
+    params?: Record<string, unknown>,
+    fileKey?: string
   ): Promise<BridgeResponse> {
     const rpcReq: RPCRequest = { tool: requestType };
     if (nodeIds && nodeIds.length > 0) rpcReq.nodeIds = nodeIds;
     if (params && Object.keys(params).length > 0) rpcReq.params = params;
+    if (fileKey) rpcReq.fileKey = fileKey;
 
     const response = await fetch(`${this.leaderUrl}/rpc`, {
       method: "POST",
@@ -44,6 +47,26 @@ export class Follower {
       requestId: "",
       data: rpcResp.data,
     };
+  }
+
+  async listConnectedFiles(): Promise<ConnectedFile[]> {
+    const response = await fetch(`${this.leaderUrl}/rpc`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ tool: "list_files" } as RPCRequest),
+      signal: AbortSignal.timeout(5_000),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Leader returned status ${response.status}`);
+    }
+
+    const rpcResp = (await response.json()) as RPCResponse;
+    if (rpcResp.error) {
+      throw new Error(rpcResp.error);
+    }
+
+    return (rpcResp.data as ConnectedFile[]) ?? [];
   }
 
   async ping(): Promise<boolean> {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -31,7 +31,7 @@ async function main(): Promise<void> {
     version: VERSION,
   });
 
-  registerTools(server, node);
+  registerTools(server, node, PORT);
 
   console.error(`Starting MCP server (role: ${node.roleName})`);
 

--- a/server/src/leader.ts
+++ b/server/src/leader.ts
@@ -47,7 +47,7 @@ export class Leader {
       server.on(
         "upgrade",
         (req: http.IncomingMessage, socket: Duplex, head: Buffer) => {
-          if (req.url === "/ws") {
+          if (req.url?.startsWith("/ws")) {
             this.bridge.handleUpgrade(req, socket, head);
           } else {
             socket.destroy();
@@ -81,6 +81,14 @@ export class Leader {
       try {
         const rpcReq: RPCRequest = JSON.parse(body);
 
+        // Handle list_files as a special RPC (not forwarded to plugin)
+        if (rpcReq.tool === "list_files") {
+          this.sendJSON(res, 200, {
+            data: this.bridge.listConnectedFiles(),
+          });
+          return;
+        }
+
         const validationError = validateRpc(
           rpcReq.tool,
           rpcReq.nodeIds,
@@ -91,12 +99,22 @@ export class Leader {
           return;
         }
 
+        const fileKey = rpcReq.fileKey;
+
         // Currently the only tool that is not forwarded to the plugin is save_screenshots
         // If more are added we need to refactor to a better abstraction.
         if (rpcReq.tool === "save_screenshots") {
           const params = rpcReq.params ?? {};
+          // Create a sender bound to the specific fileKey
+          const sender = {
+            sendWithParams: (
+              requestType: string,
+              nodeIds?: string[],
+              sendParams?: Record<string, unknown>
+            ) => this.bridge.sendWithParams(requestType, nodeIds, sendParams, fileKey),
+          };
           const result = await executeSaveScreenshots(
-            this.bridge,
+            sender,
             params.items as Parameters<typeof executeSaveScreenshots>[1],
             params.format as ExportFormat | undefined,
             params.scale as number | undefined
@@ -108,7 +126,8 @@ export class Leader {
         const resp = await this.bridge.sendWithParams(
           rpcReq.tool,
           rpcReq.nodeIds,
-          rpcReq.params
+          rpcReq.params,
+          fileKey
         );
 
         this.sendJSON(

--- a/server/src/node.ts
+++ b/server/src/node.ts
@@ -1,7 +1,7 @@
 import { Leader } from "./leader.js";
 import { Follower } from "./follower.js";
 import { Role } from "./types.js";
-import type { BridgeResponse } from "./types.js";
+import type { BridgeResponse, ConnectedFile } from "./types.js";
 
 /**
  * Node is the dynamic handler that switches between leader and follower roles.
@@ -33,22 +33,32 @@ export class Node {
 
   send(
     requestType: string,
-    nodeIds?: string[]
+    nodeIds?: string[],
+    fileKey?: string
   ): Promise<BridgeResponse> {
-    return this.sendWithParams(requestType, nodeIds);
+    return this.sendWithParams(requestType, nodeIds, undefined, fileKey);
   }
 
   sendWithParams(
     requestType: string,
     nodeIds?: string[],
-    params?: Record<string, unknown>
+    params?: Record<string, unknown>,
+    fileKey?: string
   ): Promise<BridgeResponse> {
     if (this._role === Role.Leader && this.leader) {
       return this.leader
         .getBridge()
-        .sendWithParams(requestType, nodeIds, params);
+        .sendWithParams(requestType, nodeIds, params, fileKey);
     }
-    return this.follower.sendWithParams(requestType, nodeIds, params);
+    return this.follower.sendWithParams(requestType, nodeIds, params, fileKey);
+  }
+
+  listConnectedFiles(): ConnectedFile[] {
+    if (this._role === Role.Leader && this.leader) {
+      return this.leader.getBridge().listConnectedFiles();
+    }
+    // Followers return empty — the tool handler falls back to RPC
+    return [];
   }
 
   async becomeLeader(): Promise<void> {

--- a/server/src/node.ts
+++ b/server/src/node.ts
@@ -53,12 +53,12 @@ export class Node {
     return this.follower.sendWithParams(requestType, nodeIds, params, fileKey);
   }
 
-  listConnectedFiles(): ConnectedFile[] {
+  listConnectedFiles(): ConnectedFile[] | undefined {
     if (this._role === Role.Leader && this.leader) {
       return this.leader.getBridge().listConnectedFiles();
     }
-    // Followers return empty — the tool handler falls back to RPC
-    return [];
+    // Followers return undefined — the tool handler falls back to RPC
+    return undefined;
   }
 
   async becomeLeader(): Promise<void> {

--- a/server/src/schema.ts
+++ b/server/src/schema.ts
@@ -6,9 +6,33 @@ export const figmaNodeId = z
   .regex(/^\d+:\d+$/, "Node ID must use colon format, e.g. '4029:12345'");
 const exportFormat = z.enum(["PNG", "SVG", "JPG", "PDF"]);
 
+const fileKeyField = z
+  .string()
+  .optional()
+  .describe(
+    "The fileKey of the Figma file to query. Required when multiple files are connected. Use list_files to see connected files."
+  );
+
 export const toolInputSchemas = {
+  get_document: z.object({
+    fileKey: fileKeyField,
+  }),
+
+  get_selection: z.object({
+    fileKey: fileKeyField,
+  }),
+
   get_node: z.object({
     nodeId: figmaNodeId.describe("The node ID to fetch"),
+    fileKey: fileKeyField,
+  }),
+
+  get_styles: z.object({
+    fileKey: fileKeyField,
+  }),
+
+  get_metadata: z.object({
+    fileKey: fileKeyField,
   }),
 
   get_design_context: z.object({
@@ -16,6 +40,11 @@ export const toolInputSchemas = {
       .number()
       .optional()
       .describe("How many levels deep to traverse the node tree (default 2)"),
+    fileKey: fileKeyField,
+  }),
+
+  get_variable_defs: z.object({
+    fileKey: fileKeyField,
   }),
 
   get_screenshot: z.object({
@@ -32,6 +61,7 @@ export const toolInputSchemas = {
       .number()
       .optional()
       .describe("Export scale for raster formats (default 2)"),
+    fileKey: fileKeyField,
   }),
 
   save_screenshots: z.object({
@@ -63,6 +93,7 @@ export const toolInputSchemas = {
       .number()
       .optional()
       .describe("Default export scale for raster formats (default 2)"),
+    fileKey: fileKeyField,
   }),
 } as const;
 
@@ -77,8 +108,13 @@ const rpcToArgs: Record<
   ToolName,
   (nodeIds?: string[], params?: Record<string, unknown>) => unknown
 > = {
-  get_node: (nodeIds) => ({ nodeId: nodeIds?.[0] }),
+  get_document: (_nodeIds, params) => ({ ...params }),
+  get_selection: (_nodeIds, params) => ({ ...params }),
+  get_node: (nodeIds, params) => ({ nodeId: nodeIds?.[0], ...params }),
+  get_styles: (_nodeIds, params) => ({ ...params }),
+  get_metadata: (_nodeIds, params) => ({ ...params }),
   get_design_context: (_nodeIds, params) => ({ ...params }),
+  get_variable_defs: (_nodeIds, params) => ({ ...params }),
   get_screenshot: (nodeIds, params) => ({ nodeIds, ...params }),
   save_screenshots: (_nodeIds, params) => ({ ...params }),
 };

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type { Node } from "./node.js";
 import { toolInputSchemas } from "./schema.js";
 import type { BridgeResponse } from "./types.js";
+import { Follower } from "./follower.js";
 
 type ToolResult = {
   content: Array<{ type: "text"; text: string }>;
@@ -49,16 +50,19 @@ interface SaveScreenshotItemResult {
   error?: string;
 }
 
-export function registerTools(server: McpServer, node: Node, port: number): void {
+export function registerTools(
+  server: McpServer,
+  node: Node,
+  port: number
+): void {
   server.tool(
     "list_files",
     "List all currently connected Figma files. Returns fileKey and fileName for each. Use the fileKey to target a specific file in other tools.",
     async (): Promise<ToolResult> => {
       try {
         let files = node.listConnectedFiles();
-        if (files.length === 0) {
+        if (files === undefined) {
           // Follower: fetch via RPC from leader
-          const { Follower } = await import("./follower.js");
           const follower = new Follower(`http://localhost:${port}`);
           files = await follower.listConnectedFiles();
         }
@@ -84,7 +88,9 @@ export function registerTools(server: McpServer, node: Node, port: number): void
     "Get the current Figma page document tree. When multiple files are connected, specify fileKey.",
     toolInputSchemas.get_document.shape,
     async ({ fileKey }): Promise<ToolResult> => {
-      return renderResponse(() => node.send("get_document", undefined, fileKey));
+      return renderResponse(() =>
+        node.send("get_document", undefined, fileKey)
+      );
     }
   );
 
@@ -93,7 +99,9 @@ export function registerTools(server: McpServer, node: Node, port: number): void
     "Get the currently selected nodes in Figma. When multiple files are connected, specify fileKey.",
     toolInputSchemas.get_selection.shape,
     async ({ fileKey }): Promise<ToolResult> => {
-      return renderResponse(() => node.send("get_selection", undefined, fileKey));
+      return renderResponse(() =>
+        node.send("get_selection", undefined, fileKey)
+      );
     }
   );
 
@@ -120,7 +128,9 @@ export function registerTools(server: McpServer, node: Node, port: number): void
     "Get metadata about the current Figma document including file name, pages, and current page info. When multiple files are connected, specify fileKey.",
     toolInputSchemas.get_metadata.shape,
     async ({ fileKey }): Promise<ToolResult> => {
-      return renderResponse(() => node.send("get_metadata", undefined, fileKey));
+      return renderResponse(() =>
+        node.send("get_metadata", undefined, fileKey)
+      );
     }
   );
 
@@ -144,7 +154,9 @@ export function registerTools(server: McpServer, node: Node, port: number): void
     "Get all local variable definitions including variable collections, modes, and variable values. Variables are Figma's system for design tokens (colors, numbers, strings, booleans). When multiple files are connected, specify fileKey.",
     toolInputSchemas.get_variable_defs.shape,
     async ({ fileKey }): Promise<ToolResult> => {
-      return renderResponse(() => node.send("get_variable_defs", undefined, fileKey));
+      return renderResponse(() =>
+        node.send("get_variable_defs", undefined, fileKey)
+      );
     }
   );
 
@@ -173,7 +185,12 @@ export function registerTools(server: McpServer, node: Node, port: number): void
           sendWithParams: (requestType, nodeIds, params) =>
             node.sendWithParams(requestType, nodeIds, params, fileKey),
         };
-        const result = await executeSaveScreenshots(sender, items, format, scale);
+        const result = await executeSaveScreenshots(
+          sender,
+          items,
+          format,
+          scale
+        );
         return {
           content: [{ type: "text", text: JSON.stringify(result) }],
         };

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -49,92 +49,131 @@ interface SaveScreenshotItemResult {
   error?: string;
 }
 
-export function registerTools(server: McpServer, node: Node): void {
+export function registerTools(server: McpServer, node: Node, port: number): void {
+  server.tool(
+    "list_files",
+    "List all currently connected Figma files. Returns fileKey and fileName for each. Use the fileKey to target a specific file in other tools.",
+    async (): Promise<ToolResult> => {
+      try {
+        let files = node.listConnectedFiles();
+        if (files.length === 0) {
+          // Follower: fetch via RPC from leader
+          const { Follower } = await import("./follower.js");
+          const follower = new Follower(`http://localhost:${port}`);
+          files = await follower.listConnectedFiles();
+        }
+        return {
+          content: [{ type: "text", text: JSON.stringify(files) }],
+        };
+      } catch (err) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: err instanceof Error ? err.message : String(err),
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
   server.tool(
     "get_document",
-    "Get the current Figma page document tree",
-    async (): Promise<ToolResult> => {
-      return renderResponse(() => node.send("get_document"));
+    "Get the current Figma page document tree. When multiple files are connected, specify fileKey.",
+    toolInputSchemas.get_document.shape,
+    async ({ fileKey }): Promise<ToolResult> => {
+      return renderResponse(() => node.send("get_document", undefined, fileKey));
     }
   );
 
   server.tool(
     "get_selection",
-    "Get the currently selected nodes in Figma",
-    async (): Promise<ToolResult> => {
-      return renderResponse(() => node.send("get_selection"));
+    "Get the currently selected nodes in Figma. When multiple files are connected, specify fileKey.",
+    toolInputSchemas.get_selection.shape,
+    async ({ fileKey }): Promise<ToolResult> => {
+      return renderResponse(() => node.send("get_selection", undefined, fileKey));
     }
   );
 
   server.tool(
     "get_node",
-    "Get a specific Figma node by ID. Must use colon format, e.g. '4029:12345', never use hyphens.",
+    "Get a specific Figma node by ID. Must use colon format, e.g. '4029:12345', never use hyphens. When multiple files are connected, specify fileKey.",
     toolInputSchemas.get_node.shape,
-    async ({ nodeId }): Promise<ToolResult> => {
-      return renderResponse(() => node.send("get_node", [nodeId]));
+    async ({ nodeId, fileKey }): Promise<ToolResult> => {
+      return renderResponse(() => node.send("get_node", [nodeId], fileKey));
     }
   );
 
   server.tool(
     "get_styles",
-    "Get all local styles in the document",
-    async (): Promise<ToolResult> => {
-      return renderResponse(() => node.send("get_styles"));
+    "Get all local styles in the document. When multiple files are connected, specify fileKey.",
+    toolInputSchemas.get_styles.shape,
+    async ({ fileKey }): Promise<ToolResult> => {
+      return renderResponse(() => node.send("get_styles", undefined, fileKey));
     }
   );
 
   server.tool(
     "get_metadata",
-    "Get metadata about the current Figma document including file name, pages, and current page info",
-    async (): Promise<ToolResult> => {
-      return renderResponse(() => node.send("get_metadata"));
+    "Get metadata about the current Figma document including file name, pages, and current page info. When multiple files are connected, specify fileKey.",
+    toolInputSchemas.get_metadata.shape,
+    async ({ fileKey }): Promise<ToolResult> => {
+      return renderResponse(() => node.send("get_metadata", undefined, fileKey));
     }
   );
 
   server.tool(
     "get_design_context",
-    "Get the design context for the current selection or page. Returns a summarized tree structure optimized for understanding the current design context.",
+    "Get the design context for the current selection or page. Returns a summarized tree structure optimized for understanding the current design context. When multiple files are connected, specify fileKey.",
     toolInputSchemas.get_design_context.shape,
-    async ({ depth }): Promise<ToolResult> => {
+    async ({ depth, fileKey }): Promise<ToolResult> => {
       const params: Record<string, unknown> = {};
       if (depth !== undefined && depth > 0) {
         params.depth = depth;
       }
       return renderResponse(() =>
-        node.sendWithParams("get_design_context", undefined, params)
+        node.sendWithParams("get_design_context", undefined, params, fileKey)
       );
     }
   );
 
   server.tool(
     "get_variable_defs",
-    "Get all local variable definitions including variable collections, modes, and variable values. Variables are Figma's system for design tokens (colors, numbers, strings, booleans).",
-    async (): Promise<ToolResult> => {
-      return renderResponse(() => node.send("get_variable_defs"));
+    "Get all local variable definitions including variable collections, modes, and variable values. Variables are Figma's system for design tokens (colors, numbers, strings, booleans). When multiple files are connected, specify fileKey.",
+    toolInputSchemas.get_variable_defs.shape,
+    async ({ fileKey }): Promise<ToolResult> => {
+      return renderResponse(() => node.send("get_variable_defs", undefined, fileKey));
     }
   );
 
   server.tool(
     "get_screenshot",
-    "Export a screenshot of the selected nodes or specific nodes by ID. Returns base64-encoded image data.",
+    "Export a screenshot of the selected nodes or specific nodes by ID. Returns base64-encoded image data. When multiple files are connected, specify fileKey.",
     toolInputSchemas.get_screenshot.shape,
-    async ({ nodeIds, format, scale }): Promise<ToolResult> => {
+    async ({ nodeIds, format, scale, fileKey }): Promise<ToolResult> => {
       const params: Record<string, unknown> = {};
       if (format) params.format = format;
       if (scale !== undefined && scale > 0) params.scale = scale;
       return renderResponse(() =>
-        node.sendWithParams("get_screenshot", nodeIds, params)
+        node.sendWithParams("get_screenshot", nodeIds, params, fileKey)
       );
     }
   );
 
   server.tool(
     "save_screenshots",
-    "Export screenshots for multiple nodes and save them directly to the local filesystem. Returns metadata only (no base64).",
+    "Export screenshots for multiple nodes and save them directly to the local filesystem. Returns metadata only (no base64). When multiple files are connected, specify fileKey.",
     toolInputSchemas.save_screenshots.shape,
-    async ({ items, format, scale }): Promise<ToolResult> => {
+    async ({ items, format, scale, fileKey }): Promise<ToolResult> => {
       try {
-        const result = await executeSaveScreenshots(node, items, format, scale);
+        // Create a sender bound to the specific fileKey
+        const sender: ScreenshotSender = {
+          sendWithParams: (requestType, nodeIds, params) =>
+            node.sendWithParams(requestType, nodeIds, params, fileKey),
+        };
+        const result = await executeSaveScreenshots(sender, items, format, scale);
         return {
           content: [{ type: "text", text: JSON.stringify(result) }],
         };

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -16,11 +16,17 @@ export interface RPCRequest {
   tool: string;
   nodeIds?: string[];
   params?: Record<string, unknown>;
+  fileKey?: string;
 }
 
 export interface RPCResponse {
   data?: unknown;
   error?: string;
+}
+
+export interface ConnectedFile {
+  fileKey: string;
+  fileName: string;
 }
 
 export enum Role {


### PR DESCRIPTION
## Summary

Lets multiple Figma files be connected to the bridge at the same time, so an agent can query any of them by `fileKey`. Backward compatible: a single connected file works without any tool changes.

## Motivation

When working across a design-system file and a product file (common for anyone using tokens/components from another file), you currently have to disconnect one to talk to the other. This change removes that constraint.

## Changes

**Bridge (`server/src/bridge.ts`)**
- Single `ws` connection → `Map<fileKey, ConnectionEntry>`
- `handleUpgrade` extracts `fileKey` + `fileName` from WS query params
- New `resolveConnection(fileKey?)`:
  - explicit `fileKey` → that connection
  - single connection + no key → that connection (backward-compat)
  - multiple connections + no key → error listing connected files and pointing at `list_files`

**Tools (`server/src/schema.ts`, `tools.ts`)**
- Every existing tool accepts an optional `fileKey`
- New `list_files` tool returns `[{ fileKey, fileName }, ...]`

**Plugin (`plugin/src/main/code.ts`, `ui/App.tsx`)**
- Sends `figma.fileKey` + `figma.root.name` as WS query params on connect

**RPC plumbing (`follower.ts`, `leader.ts`, `node.ts`)**
- `list_files` works in follower processes by forwarding to the leader over the existing HTTP RPC channel

## Backward compatibility

- Single-file users: no change in behavior, `fileKey` is optional
- WS protocol: connections without `fileKey` are now rejected. In practice only this plugin connects, so this is safe — but flagging explicitly

## Notes for reviewers

- Happy to split the `list_files` RPC plumbing into a separate commit if that's easier to review
- The error message for "multiple files, no fileKey specified" is tuned for MCP agents (lists connected files inline) — open to suggestions if you'd prefer a different shape

## Test plan

- [ ] Single file connected, no `fileKey` passed → all existing tools work unchanged
- [ ] Two files connected, no `fileKey` → tools return a helpful error listing available files
- [ ] Two files connected, explicit `fileKey` → correct file responds
- [ ] `list_files` returns accurate list as files connect/disconnect

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for concurrent connections to multiple files with per-file routing via a new fileKey.
  * UI and connection logic now target specific files and reconnect based on fileKey/fileName.
  * Added a tool to list connected files.

* **Documentation**
  * README updated with multi-file guidance and fileKey usage for routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->