### PR TITLE
fix: address PR #20 review feedback (multi-file)

### DIFF
--- a/plugin/src/main/code.ts
+++ b/plugin/src/main/code.ts
@@ -28,8 +28,17 @@ type PluginResponse = {
   error?: string;
 };
 
+let cachedFallbackFileKey: string | null = null;
+
+const generateFallbackFileKey = (): string => {
+  const random = Math.random().toString(36).slice(2, 10);
+  return `unsaved-${Date.now().toString(36)}-${random}`;
+};
+
 const getFileKey = (): string => {
-  // figma.fileKey is available for saved files; fall back to root name
+  // figma.fileKey is available for saved files; otherwise we generate a
+  // session-scoped fallback so unsaved files (and files with duplicate names)
+  // still get a stable, unique identifier for this plugin instance.
   try {
     if (typeof figma.fileKey === "string" && figma.fileKey) {
       return figma.fileKey;
@@ -37,7 +46,16 @@ const getFileKey = (): string => {
   } catch {
     // fileKey may not be available in all contexts
   }
-  return figma.root.name;
+  if (!cachedFallbackFileKey) {
+    cachedFallbackFileKey = generateFallbackFileKey();
+    console.warn(
+      `[figma-mcp-bridge] figma.fileKey unavailable for "${figma.root.name}". ` +
+        `Using session fallback key "${cachedFallbackFileKey}". ` +
+        `If you encounter this in a built plugin, please report at ` +
+        `https://github.com/gethopp/figma-mcp-bridge/issues with steps to reproduce.`
+    );
+  }
+  return cachedFallbackFileKey;
 };
 
 const sendStatus = () => {

--- a/plugin/src/ui/App.tsx
+++ b/plugin/src/ui/App.tsx
@@ -82,7 +82,11 @@ export default function App() {
   useEffect(() => {
     if (!status.fileKey) return;
 
+    let disposed = false;
+
     const connect = () => {
+      if (disposed) return;
+
       if (socketRef.current) {
         socketRef.current.close();
       }
@@ -97,6 +101,7 @@ export default function App() {
       };
 
       ws.onclose = () => {
+        if (disposed || socketRef.current !== ws) return;
         setConnected(false);
         if (reconnectTimer.current === null) {
           reconnectTimer.current = window.setTimeout(() => {
@@ -107,6 +112,7 @@ export default function App() {
       };
 
       ws.onerror = () => {
+        if (disposed || socketRef.current !== ws) return;
         setConnected(false);
       };
 
@@ -119,12 +125,18 @@ export default function App() {
     connect();
 
     return () => {
+      disposed = true;
       if (reconnectTimer.current !== null) {
         window.clearTimeout(reconnectTimer.current);
         reconnectTimer.current = null;
       }
       if (socketRef.current) {
-        socketRef.current.close();
+        const ws = socketRef.current;
+        ws.onopen = null;
+        ws.onclose = null;
+        ws.onerror = null;
+        ws.onmessage = null;
+        ws.close();
         socketRef.current = null;
       }
     };

--- a/server/src/bridge.ts
+++ b/server/src/bridge.ts
@@ -7,6 +7,7 @@ interface PendingRequest {
   resolve: (resp: BridgeResponse) => void;
   reject: (err: Error) => void;
   timeout: ReturnType<typeof setTimeout>;
+  ws: WebSocket;
 }
 
 interface ConnectionEntry {
@@ -81,6 +82,10 @@ export class Bridge {
         this.connections.delete(fileKey);
         console.error(`Plugin disconnected: ${fileName} (${fileKey})`);
       }
+      this.rejectPendingForSocket(
+        ws,
+        `Plugin disconnected: ${fileName} (${fileKey})`
+      );
     });
 
     ws.on("error", (err) => {
@@ -89,7 +94,21 @@ export class Bridge {
       if (current?.ws === ws) {
         this.connections.delete(fileKey);
       }
+      this.rejectPendingForSocket(
+        ws,
+        `Plugin connection error (${fileName}): ${err.message}`
+      );
     });
+  }
+
+  private rejectPendingForSocket(ws: WebSocket, reason: string): void {
+    for (const [id, p] of this.pending) {
+      if (p.ws === ws) {
+        clearTimeout(p.timeout);
+        this.pending.delete(id);
+        p.reject(new Error(reason));
+      }
+    }
   }
 
   /**
@@ -181,7 +200,7 @@ export class Bridge {
         reject(new Error("Request timed out"));
       }, 30_000);
 
-      this.pending.set(requestId, { resolve, reject, timeout });
+      this.pending.set(requestId, { resolve, reject, timeout, ws: conn });
 
       conn.send(JSON.stringify(request), (err) => {
         if (err) {

--- a/server/src/leader.ts
+++ b/server/src/leader.ts
@@ -47,7 +47,11 @@ export class Leader {
       server.on(
         "upgrade",
         (req: http.IncomingMessage, socket: Duplex, head: Buffer) => {
-          if (req.url?.startsWith("/ws")) {
+          const pathname = new URL(
+            req.url ?? "",
+            "http://localhost"
+          ).pathname;
+          if (pathname === "/ws") {
             this.bridge.handleUpgrade(req, socket, head);
           } else {
             socket.destroy();

--- a/server/src/schema.ts
+++ b/server/src/schema.ts
@@ -110,7 +110,7 @@ const rpcToArgs: Record<
 > = {
   get_document: (_nodeIds, params) => ({ ...params }),
   get_selection: (_nodeIds, params) => ({ ...params }),
-  get_node: (nodeIds, params) => ({ nodeId: nodeIds?.[0], ...params }),
+  get_node: (nodeIds, params) => ({ ...params, nodeId: nodeIds?.[0] }),
   get_styles: (_nodeIds, params) => ({ ...params }),
   get_metadata: (_nodeIds, params) => ({ ...params }),
   get_design_context: (_nodeIds, params) => ({ ...params }),


### PR DESCRIPTION
## Summary

Follow-ups to the review thread on #20. Five small, independent fixes — each as its own commit so they can be reviewed (or split out) individually.

| Commit | Issue | Source |
|---|---|---|
| `fix(plugin): give unsaved files a stable, unique fileKey + warn on fallback` | Fallback to \`figma.root.name\` collided across files with the same name and ran silently | @konsalex's comment on \`plugin/src/main/code.ts:38\` + CodeRabbit |
| `fix(schema): prevent params.nodeId from overriding nodeIds in get_node` | \`get_node\` validated locally with only \`params.nodeId\` but failed downstream because the leader forwards \`nodeIds\` | CodeRabbit (Minor) |
| `fix(ui): prevent stale sockets from reconnecting to an old file` | \`onclose\` could reconnect through a stale closure after \`fileKey\`/\`fileName\` changed, then close the new socket | CodeRabbit (Major) |
| `fix(leader): match /ws upgrade pathname exactly` | \`startsWith(\"/ws\")\` accepted \`/ws-anything\` | CodeRabbit (Minor) |
| `fix(bridge): reject pending requests when their plugin disconnects` | In-flight requests waited the full 30s timeout on disconnect, then surfaced a misleading \"Request timed out\" | CodeRabbit (nit, but functionally important) |

## Notes

- The plugin fallback key is intentionally session-scoped (a fresh random string per plugin run) rather than persisted in \`figma.clientStorage\`. \`clientStorage\` is shared across all open files for the plugin install, so persisting one key there would re-introduce the collision it's meant to avoid. Per-session is enough to keep the WebSocket connection stable for the lifetime of the plugin window, which is the relevant scope.
- The \`console.warn\` includes the project's GitHub URL so users can copy-paste the message into a report.
- The bridge fix tags each pending request with its owning \`WebSocket\`, then rejects matching entries from \`close\`/\`error\` handlers. No behavior change for healthy requests — only the failure path improves.

## Test plan

- [ ] Unsaved file → check console: \`[figma-mcp-bridge] figma.fileKey unavailable...\` warn fires once and the bridge accepts the connection
- [ ] Two unsaved files with the same name → each gets a distinct fileKey
- [ ] \`get_node\` with only \`params.nodeId\` (no \`nodeIds\`) → request reaches the plugin correctly
- [ ] Switch files in Figma without closing the plugin → no reconnect to the previous file
- [ ] Connect to \`/ws-foo\` directly → upgrade rejected
- [ ] Issue a request, then kill the plugin → caller gets a \"Plugin disconnected\" error within milliseconds, not after 30s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unsaved file identification with consistent fallback keys
  * Enhanced connection stability with better cleanup of stale callbacks and reconnection handlers
  * Faster error detection and immediate rejection of pending requests when connections drop, preventing request timeouts
  * Stricter validation of connection endpoint paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->