### PR TITLE
fix(schema): accept instance-child node IDs in figmaNodeId

### DIFF
--- a/server/src/schema.ts
+++ b/server/src/schema.ts
@@ -1,9 +1,19 @@
 import { z } from "zod";
 
-/** Figma node IDs use colon-separated format, e.g. "4029:12345". */
+/**
+ * Figma node IDs:
+ *   - top-level node:        "4029:12345"
+ *   - child inside INSTANCE: "I12740:17806;12740:17793" (and deeper, semicolon-separated)
+ *
+ * Both forms are valid for figma.getNodeById and are returned as-is by the plugin
+ * from get_selection / get_design_context.
+ */
 export const figmaNodeId = z
   .string()
-  .regex(/^\d+:\d+$/, "Node ID must use colon format, e.g. '4029:12345'");
+  .regex(
+    /^(\d+:\d+|I\d+:\d+(;\d+:\d+)+)$/,
+    "Node ID must use colon format, e.g. '4029:12345', or instance-child format 'I12740:17806;12740:17793'"
+  );
 const exportFormat = z.enum(["PNG", "SVG", "JPG", "PDF"]);
 
 const fileKeyField = z
@@ -23,7 +33,9 @@ export const toolInputSchemas = {
   }),
 
   get_node: z.object({
-    nodeId: figmaNodeId.describe("The node ID to fetch"),
+    nodeId: figmaNodeId.describe(
+      "The node ID to fetch. Accepts top-level IDs like '4029:12345' and instance-child IDs like 'I12740:17806;12740:17793'."
+    ),
     fileKey: fileKeyField,
   }),
 
@@ -52,7 +64,7 @@ export const toolInputSchemas = {
       .array(figmaNodeId)
       .optional()
       .describe(
-        "Optional list of node IDs to export (colon-separated format, e.g. '4029:12345' — never use hyphens). If empty, exports the current selection",
+        "Optional list of node IDs to export. Accepts top-level IDs like '4029:12345' and instance-child IDs like 'I12740:17806;12740:17793'. Never use hyphens. If empty, exports the current selection.",
       ),
     format: exportFormat
       .optional()
@@ -68,7 +80,9 @@ export const toolInputSchemas = {
     items: z
       .array(
         z.object({
-          nodeId: figmaNodeId.describe("The node ID to export"),
+          nodeId: figmaNodeId.describe(
+            "The node ID to export. Accepts top-level IDs like '4029:12345' and instance-child IDs like 'I12740:17806;12740:17793'."
+          ),
           outputPath: z
             .string()
             .min(1)

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -107,7 +107,7 @@ export function registerTools(
 
   server.tool(
     "get_node",
-    "Get a specific Figma node by ID. Must use colon format, e.g. '4029:12345', never use hyphens. When multiple files are connected, specify fileKey.",
+    "Get a specific Figma node by ID. Accepts top-level IDs like '4029:12345' and instance-child IDs like 'I12740:17806;12740:17793'. Never use hyphens. When multiple files are connected, specify fileKey.",
     toolInputSchemas.get_node.shape,
     async ({ nodeId, fileKey }): Promise<ToolResult> => {
       return renderResponse(() => node.send("get_node", [nodeId], fileKey));


### PR DESCRIPTION
Fixes #24.

## Summary

`figmaNodeId` only accepted `^\d+:\d+$`, so any node ID with an `I…;…` instance-child form was rejected by the input validator before reaching the plugin. The bridge itself returns these IDs in `get_selection` / `get_design_context`, so the validation was internally inconsistent and made instance children unreachable through `get_node` / `get_screenshot` / `save_screenshots`.

This PR:

- Widens the regex to `/^(\d+:\d+|I\d+:\d+(;\d+:\d+)+)$/` — accepts top-level IDs and instance-child IDs (including deeper chains), rejects bare `I12740:17806` without a `;<child>` segment since the `I` prefix only makes sense with at least one child segment.
- Updates the `.describe(...)` strings on `get_node.nodeId`, `get_screenshot.nodeIds`, `save_screenshots.items[].nodeId` and the top-level `get_node` tool description to mention the instance-child form. The previous wording (`"never use hyphens"`, `"colon format only"`) actively misled LLM clients away from a form the plugin actually supports.

## Test plan

Manual unit check against the rebuilt `dist/schema.js`:

```js
import { figmaNodeId } from "./dist/schema.js";

// positive
figmaNodeId.safeParse("4029:12345").success                          // true
figmaNodeId.safeParse("I12740:17806;12740:17793").success            // true
figmaNodeId.safeParse("I12740:17806;12740:17793;12740:17794").success// true

// negative
figmaNodeId.safeParse("foo-bar").success                             // false
figmaNodeId.safeParse(":5").success                                  // false
figmaNodeId.safeParse("1:").success                                  // false
figmaNodeId.safeParse("I12740:17806").success                        // false  (bare I-prefix without child)
figmaNodeId.safeParse("").success                                    // false
```

All eight cases pass against this branch's built artifact. No tests are checked in to the repo so I haven't added a test file — happy to do so if you have a preference for location/framework.

## Reproducing the bug on `main`

1. Open a Figma file with an `INSTANCE` in Figma Desktop, plugin running.
2. `get_selection` or `get_design_context` returns child nodes whose ids look like `I12740:17806;12740:17793`.
3. `save_screenshots` (or `get_screenshot` / `get_node`) with that id fails:

```
MCP error -32602: Input validation error: Invalid arguments for tool save_screenshots: [
  {
    "validation": "regex",
    "code": "invalid_string",
    "message": "Node ID must use colon format, e.g. '4029:12345'",
    "path": ["items", 0, "nodeId"]
  }
]
```

Issue #24 has the full repro.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended node ID format support to include instance-child identifiers, allowing more flexible node reference options alongside existing top-level formats.

* **Documentation**
  * Updated tool descriptions and input field documentation to clarify newly supported node ID format specifications and validation rules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gethopp/figma-mcp-bridge/pull/25?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->