### PR TITLE
Export Image Clip API Support

### DIFF
--- a/plugin/src/main/code.ts
+++ b/plugin/src/main/code.ts
@@ -30,11 +30,24 @@ type RequestType =
   | "scroll_and_zoom_into_view"
   | "delete_nodes";
 
+type ServerRequestParams = Record<string, unknown> & {
+  format?: "PNG" | "SVG" | "JPG" | "PDF";
+  scale?: number;
+  /**
+   * When true, export the node using its absolute bounds (the same behavior
+   * exposed by Figma REST image export via `use_absolute_bounds`). This clips
+   * raster exports such as PNG to the node's logical bounds instead of the
+   * rendered/tight bounds including overflow/effects.
+   */
+  clip?: boolean;
+  depth?: number;
+};
+
 type ServerRequest = {
   type: RequestType;
   requestId: string;
   nodeIds?: string[];
-  params?: Record<string, unknown>;
+  params?: ServerRequestParams;
 };
 
 type PluginResponse = {
@@ -559,6 +572,7 @@ const handleRequest = async (
             : "PNG";
         const scale =
           typeof request.params?.scale === "number" ? request.params.scale : 2;
+        const clip = request.params?.clip === true;
 
         // Determine which node(s) to export
         let targetNodes: SceneNode[];
@@ -582,19 +596,24 @@ const handleRequest = async (
 
         const exports = await Promise.all(
           targetNodes.map(async (node) => {
+            const commonSettings = clip
+              ? { contentsOnly: true, useAbsoluteBounds: true }
+              : {};
             const settings: ExportSettings =
               format === "SVG"
-                ? { format: "SVG" }
+                ? { format: "SVG", ...commonSettings }
                 : format === "PDF"
-                  ? { format: "PDF" }
+                  ? { format: "PDF", ...commonSettings }
                   : format === "JPG"
                     ? {
                         format: "JPG",
                         constraint: { type: "SCALE", value: scale },
+                        ...commonSettings,
                       }
                     : {
                         format: "PNG",
                         constraint: { type: "SCALE", value: scale },
+                        ...commonSettings,
                       };
 
             const bytes = await node.exportAsync(settings);

--- a/server/src/leader.ts
+++ b/server/src/leader.ts
@@ -47,10 +47,7 @@ export class Leader {
       server.on(
         "upgrade",
         (req: http.IncomingMessage, socket: Duplex, head: Buffer) => {
-          const pathname = new URL(
-            req.url ?? "",
-            "http://localhost"
-          ).pathname;
+          const pathname = new URL(req.url ?? "", "http://localhost").pathname;
           if (pathname === "/ws") {
             this.bridge.handleUpgrade(req, socket, head);
           } else {
@@ -115,13 +112,20 @@ export class Leader {
               requestType: string,
               nodeIds?: string[],
               sendParams?: Record<string, unknown>
-            ) => this.bridge.sendWithParams(requestType, nodeIds, sendParams, fileKey),
+            ) =>
+              this.bridge.sendWithParams(
+                requestType,
+                nodeIds,
+                sendParams,
+                fileKey
+              ),
           };
           const result = await executeSaveScreenshots(
             sender,
             params.items as Parameters<typeof executeSaveScreenshots>[1],
             params.format as ExportFormat | undefined,
-            params.scale as number | undefined
+            params.scale as number | undefined,
+            params.clip as boolean | undefined
           );
           this.sendJSON(res, 200, { data: result });
           return;

--- a/server/src/schema.ts
+++ b/server/src/schema.ts
@@ -542,6 +542,12 @@ export const toolInputSchemas = {
       .number()
       .optional()
       .describe("Export scale for raster formats (default 2)"),
+    clip: z
+      .boolean()
+      .optional()
+      .describe(
+        "When true, export using Figma's absolute node bounds (REST use_absolute_bounds / plugin useAbsoluteBounds) so PNGs are clipped to the node's logical bounds",
+      ),
     fileKey: fileKeyField,
   }),
 
@@ -681,6 +687,12 @@ export const toolInputSchemas = {
             .number()
             .optional()
             .describe("Per-item export scale override for raster formats"),
+          clip: z
+            .boolean()
+            .optional()
+            .describe(
+              "Per-item clipping override. When true, PNGs are clipped to the node's logical bounds using Figma's absolute node bounds.",
+            ),
         }),
       )
       .min(1)
@@ -692,6 +704,12 @@ export const toolInputSchemas = {
       .number()
       .optional()
       .describe("Default export scale for raster formats (default 2)"),
+    clip: z
+      .boolean()
+      .optional()
+      .describe(
+        "Default clipping behavior for saved screenshots. When true, PNGs are clipped to the node's logical bounds using Figma's absolute node bounds.",
+      ),
     fileKey: fileKeyField,
   }),
 } as const;

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -209,7 +209,12 @@ export function registerTools(
     toolInputSchemas.set_node_visibility.shape,
     async ({ items, fileKey }): Promise<ToolResult> => {
       return renderResponse(() =>
-        node.sendWithParams("set_node_visibility", undefined, { items }, fileKey)
+        node.sendWithParams(
+          "set_node_visibility",
+          undefined,
+          { items },
+          fileKey
+        )
       );
     }
   );
@@ -234,7 +239,12 @@ export function registerTools(
       if (!parsed.success) return parsed.error;
       const { nodeId, fileKey, ...properties } = parsed.data;
       return renderResponse(() =>
-        node.sendWithParams("set_text_properties", [nodeId], properties, fileKey)
+        node.sendWithParams(
+          "set_text_properties",
+          [nodeId],
+          properties,
+          fileKey
+        )
       );
     }
   );
@@ -248,7 +258,12 @@ export function registerTools(
       if (!parsed.success) return parsed.error;
       const { nodeId, fileKey, ...properties } = parsed.data;
       return renderResponse(() =>
-        node.sendWithParams("set_node_properties", [nodeId], properties, fileKey)
+        node.sendWithParams(
+          "set_node_properties",
+          [nodeId],
+          properties,
+          fileKey
+        )
       );
     }
   );
@@ -291,7 +306,10 @@ export function registerTools(
     "Patch stroke geometry properties: weight, align, dash pattern, cap, join. Use set_solid_fill/set_gradient_fill with target='stroke' to set the paint itself.",
     setStrokePropertiesInput.shape,
     async (args): Promise<ToolResult> => {
-      const parsed = parseToolInput(toolInputSchemas.set_stroke_properties, args);
+      const parsed = parseToolInput(
+        toolInputSchemas.set_stroke_properties,
+        args
+      );
       if (!parsed.success) return parsed.error;
       const { nodeId, fileKey, ...params } = parsed.data;
       return renderResponse(() =>
@@ -362,7 +380,10 @@ export function registerTools(
     createImageInput.shape,
     async ({ source, fileKey, ...params }): Promise<ToolResult> => {
       try {
-        const imageBase64 = await loadImageSourceAsBase64(source, process.cwd());
+        const imageBase64 = await loadImageSourceAsBase64(
+          source,
+          process.cwd()
+        );
         return await renderResponse(() =>
           node.sendWithParams(
             "create_image",
@@ -446,7 +467,12 @@ export function registerTools(
     scrollAndZoomIntoViewInput.shape,
     async ({ nodeIds, fileKey }): Promise<ToolResult> => {
       return renderResponse(() =>
-        node.sendWithParams("scroll_and_zoom_into_view", nodeIds, undefined, fileKey)
+        node.sendWithParams(
+          "scroll_and_zoom_into_view",
+          nodeIds,
+          undefined,
+          fileKey
+        )
       );
     }
   );
@@ -639,7 +665,10 @@ async function fetchImageBytes(source: string): Promise<Buffer> {
     await assertSafeHttpUrl(url);
 
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), IMAGE_FETCH_TIMEOUT_MS);
+    const timeout = setTimeout(
+      () => controller.abort(),
+      IMAGE_FETCH_TIMEOUT_MS
+    );
     let resp: Response;
     try {
       resp = await fetch(url, {
@@ -648,7 +677,9 @@ async function fetchImageBytes(source: string): Promise<Buffer> {
       });
     } catch (err) {
       if (err instanceof Error && err.name === "AbortError") {
-        throw new Error(`Timed out fetching image after ${IMAGE_FETCH_TIMEOUT_MS}ms`);
+        throw new Error(
+          `Timed out fetching image after ${IMAGE_FETCH_TIMEOUT_MS}ms`
+        );
       }
       throw err;
     } finally {
@@ -658,18 +689,24 @@ async function fetchImageBytes(source: string): Promise<Buffer> {
     if (resp.status >= 300 && resp.status < 400) {
       const location = resp.headers.get("location");
       if (!location) {
-        throw new Error(`Image redirect missing Location header: ${resp.status}`);
+        throw new Error(
+          `Image redirect missing Location header: ${resp.status}`
+        );
       }
       redirects += 1;
       if (redirects > MAX_IMAGE_REDIRECTS) {
-        throw new Error(`Image fetch exceeded ${MAX_IMAGE_REDIRECTS} redirects`);
+        throw new Error(
+          `Image fetch exceeded ${MAX_IMAGE_REDIRECTS} redirects`
+        );
       }
       url = new URL(location, url);
       continue;
     }
 
     if (!resp.ok) {
-      throw new Error(`Failed to fetch image: ${resp.status} ${resp.statusText}`);
+      throw new Error(
+        `Failed to fetch image: ${resp.status} ${resp.statusText}`
+      );
     }
 
     const contentLength = resp.headers.get("content-length");

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -62,6 +62,7 @@ interface SaveScreenshotItemInput {
   outputPath: string;
   format?: ExportFormat;
   scale?: number;
+  clip?: boolean;
 }
 
 interface SaveScreenshotItemResult {
@@ -191,10 +192,11 @@ export function registerTools(
     "get_screenshot",
     "Export a screenshot of the selected nodes or specific nodes by ID. Returns base64-encoded image data. When multiple files are connected, specify fileKey.",
     toolInputSchemas.get_screenshot.shape,
-    async ({ nodeIds, format, scale, fileKey }): Promise<ToolResult> => {
+    async ({ nodeIds, format, scale, clip, fileKey }): Promise<ToolResult> => {
       const params: Record<string, unknown> = {};
       if (format) params.format = format;
       if (scale !== undefined && scale > 0) params.scale = scale;
+      if (clip !== undefined) params.clip = clip;
       return renderResponse(() =>
         node.sendWithParams("get_screenshot", nodeIds, params, fileKey)
       );
@@ -464,7 +466,7 @@ export function registerTools(
     "save_screenshots",
     "Export screenshots for multiple nodes and save them directly to the local filesystem. Returns metadata only (no base64). When multiple files are connected, specify fileKey.",
     toolInputSchemas.save_screenshots.shape,
-    async ({ items, format, scale, fileKey }): Promise<ToolResult> => {
+    async ({ items, format, scale, clip, fileKey }): Promise<ToolResult> => {
       try {
         // Create a sender bound to the specific fileKey
         const sender: ScreenshotSender = {
@@ -475,7 +477,8 @@ export function registerTools(
           sender,
           items,
           format,
-          scale
+          scale,
+          clip
         );
         return {
           content: [{ type: "text", text: JSON.stringify(result) }],
@@ -499,7 +502,8 @@ export async function executeSaveScreenshots(
   sender: ScreenshotSender,
   items: SaveScreenshotItemInput[],
   format?: ExportFormat,
-  scale?: number
+  scale?: number,
+  clip?: boolean
 ): Promise<{
   total: number;
   succeeded: number;
@@ -516,7 +520,8 @@ export async function executeSaveScreenshots(
       index,
       process.cwd(),
       format,
-      scale
+      scale,
+      clip
     );
     results.push(result);
   }
@@ -828,7 +833,8 @@ async function saveScreenshotItemToFile(
   index: number,
   workspaceRoot: string,
   defaultFormat?: ExportFormat,
-  defaultScale?: number
+  defaultScale?: number,
+  defaultClip?: boolean
 ): Promise<SaveScreenshotItemResult> {
   let resolvedOutputPath = item.outputPath;
 
@@ -843,10 +849,14 @@ async function saveScreenshotItemToFile(
       inferredFormat
     );
     const resolvedScale = resolveScale(item.scale, defaultScale);
+    const resolvedClip = item.clip ?? defaultClip;
 
     const params: Record<string, unknown> = { format: resolvedFormat };
     if (resolvedScale !== undefined) {
       params.scale = resolvedScale;
+    }
+    if (resolvedClip !== undefined) {
+      params.clip = resolvedClip;
     }
 
     const resp = await sender.sendWithParams(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional "clip" option for screenshot exports to control clipping to a node’s logical bounds (applies to single and batch exports; per-item overrides supported).
  * Ensures consistent export behavior by applying shared export settings (contents-only + absolute bounds) across formats while preserving existing per-format rules (including raster scale limits).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->