### PR TITLE
Fix Moonshot MCP schema rejection from repeated Zod refs

### DIFF
--- a/server/src/schema.ts
+++ b/server/src/schema.ts
@@ -8,16 +8,22 @@ import { z } from "zod";
  * Both forms are valid for figma.getNodeById and are returned as-is by the plugin
  * from get_selection / get_design_context.
  */
-export const figmaNodeId = z
+const createFigmaNodeIdSchema = () => z
   .string()
   .regex(
     /^(\d+:\d+|I\d+:\d+(;\d+:\d+)+)$/,
     "Node ID must use colon format, e.g. '4029:12345', or instance-child format 'I12740:17806;12740:17793'"
   );
-const exportFormat = z.enum(["PNG", "SVG", "JPG", "PDF"]);
-const hexColor = z
+
+export const figmaNodeId = createFigmaNodeIdSchema();
+
+const createExportFormatSchema = () => z.enum(["PNG", "SVG", "JPG", "PDF"]);
+const exportFormat = createExportFormatSchema();
+
+const createHexColorSchema = () => z
   .string()
   .regex(/^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/, "Color must be a hex value like '#FFAA00'");
+const hexColor = createHexColorSchema();
 const textAlignHorizontal = z.enum(["LEFT", "CENTER", "RIGHT", "JUSTIFIED"]);
 const textAlignVertical = z.enum(["TOP", "CENTER", "BOTTOM"]);
 const textAutoResize = z.enum(["NONE", "WIDTH_AND_HEIGHT", "HEIGHT", "TRUNCATE"]);
@@ -37,7 +43,7 @@ const gradientStop = z.object({
     .min(0)
     .max(1)
     .describe("Stop position from 0 (start of gradient) to 1 (end)"),
-  hex: hexColor.describe("Stop color as hex"),
+  hex: createHexColorSchema().describe("Stop color as hex"),
   opacity: z
     .number()
     .min(0)
@@ -56,7 +62,7 @@ const gradientTransform = z
   );
 
 export const setGradientFillInput = z.object({
-  nodeId: figmaNodeId.describe("The node ID to update"),
+  nodeId: createFigmaNodeIdSchema().describe("The node ID to update"),
   gradientType: z
     .enum(["LINEAR", "RADIAL", "ANGULAR", "DIAMOND"])
     .optional()
@@ -80,7 +86,7 @@ export const setGradientFillInput = z.object({
 });
 
 export const setNodePropertiesInput = z.object({
-  nodeId: figmaNodeId.describe("The node ID to update"),
+  nodeId: createFigmaNodeIdSchema().describe("The node ID to update"),
   name: z.string().optional().describe("Optional new node name"),
   x: z.number().optional().describe("Optional x position"),
   y: z.number().optional().describe("Optional y position"),
@@ -103,8 +109,8 @@ export const setNodePropertiesInput = z.object({
 });
 
 export const setSolidFillInput = z.object({
-  nodeId: figmaNodeId.describe("The node ID to update"),
-  hex: hexColor.describe("Solid color as hex (e.g. '#FFAA00')"),
+  nodeId: createFigmaNodeIdSchema().describe("The node ID to update"),
+  hex: createHexColorSchema().describe("Solid color as hex (e.g. '#FFAA00')"),
   opacity: z
     .number()
     .min(0)
@@ -142,7 +148,7 @@ const blendMode = z.enum([
 
 const shadowEffect = z.object({
   type: z.enum(["DROP_SHADOW", "INNER_SHADOW"]),
-  color: hexColor.describe("Shadow color as hex"),
+  color: createHexColorSchema().describe("Shadow color as hex"),
   opacity: z
     .number()
     .min(0)
@@ -174,14 +180,14 @@ const blurEffect = z.object({
 
 export const setSelectionInput = z.object({
   nodeIds: z
-    .array(figmaNodeId)
+    .array(createFigmaNodeIdSchema())
     .describe("Node IDs to select. Pass [] to clear the selection."),
   fileKey: fileKeyField,
 });
 
 export const scrollAndZoomIntoViewInput = z.object({
   nodeIds: z
-    .array(figmaNodeId)
+    .array(createFigmaNodeIdSchema())
     .min(1)
     .describe("Node IDs to frame in the viewport"),
   fileKey: fileKeyField,
@@ -189,10 +195,10 @@ export const scrollAndZoomIntoViewInput = z.object({
 
 export const groupNodesInput = z.object({
   nodeIds: z
-    .array(figmaNodeId)
+    .array(createFigmaNodeIdSchema())
     .min(1)
     .describe("Node IDs to group. Must share a common parent."),
-  parentId: figmaNodeId
+  parentId: createFigmaNodeIdSchema()
     .optional()
     .describe(
       "Optional explicit parent for the new group. Defaults to the shared parent of the input nodes."
@@ -202,14 +208,14 @@ export const groupNodesInput = z.object({
 });
 
 export const ungroupNodeInput = z.object({
-  nodeId: figmaNodeId.describe(
+  nodeId: createFigmaNodeIdSchema().describe(
     "Group or frame to ungroup. Children move up to its parent and the wrapper is removed."
   ),
   fileKey: fileKeyField,
 });
 
 export const setEffectsInput = z.object({
-  nodeId: figmaNodeId.describe("The node ID to update"),
+  nodeId: createFigmaNodeIdSchema().describe("The node ID to update"),
   effects: z
     .array(z.discriminatedUnion("type", [shadowEffect, blurEffect]))
     .describe(
@@ -219,7 +225,7 @@ export const setEffectsInput = z.object({
 });
 
 export const setStrokePropertiesInput = z.object({
-  nodeId: figmaNodeId.describe("The node ID to update"),
+  nodeId: createFigmaNodeIdSchema().describe("The node ID to update"),
   strokeWeight: z
     .number()
     .min(0)
@@ -253,7 +259,7 @@ export const setStrokePropertiesInput = z.object({
 });
 
 export const setAutoLayoutInput = z.object({
-  nodeId: figmaNodeId.describe("The node ID to update (must be a frame)"),
+  nodeId: createFigmaNodeIdSchema().describe("The node ID to update (must be a frame)"),
   layoutMode: z
     .enum(["NONE", "HORIZONTAL", "VERTICAL"])
     .optional()
@@ -295,14 +301,14 @@ export const setAutoLayoutInput = z.object({
 
 export const createFrameInput = z.object({
   name: z.string().optional().describe("Optional frame name"),
-  parentId: figmaNodeId
+  parentId: createFigmaNodeIdSchema()
     .optional()
     .describe("Optional parent node ID to append the frame into"),
   x: z.number().optional().describe("Optional x position"),
   y: z.number().optional().describe("Optional y position"),
   width: z.number().positive().optional().describe("Frame width"),
   height: z.number().positive().optional().describe("Frame height"),
-  fillHex: hexColor
+  fillHex: createHexColorSchema()
     .optional()
     .describe("Optional solid fill color as hex"),
   fillOpacity: z
@@ -315,7 +321,7 @@ export const createFrameInput = z.object({
 });
 
 export const setTextPropertiesShape = z.object({
-  nodeId: figmaNodeId.describe("The text node ID to update"),
+  nodeId: createFigmaNodeIdSchema().describe("The text node ID to update"),
   fontFamily: z.string().optional().describe("Optional font family"),
   fontStyle: z.string().optional().describe("Optional font style"),
   fontSize: z.number().positive().optional().describe("Optional font size"),
@@ -337,7 +343,7 @@ export const setTextPropertiesShape = z.object({
     .number()
     .optional()
     .describe("Optional letter spacing in pixels"),
-  fillHex: hexColor.optional().describe("Optional text fill color as hex"),
+  fillHex: createHexColorSchema().optional().describe("Optional text fill color as hex"),
   fillOpacity: z
     .number()
     .min(0)
@@ -377,7 +383,7 @@ export const setTextPropertiesInput = setTextPropertiesShape
 
 export const createTextShape = z.object({
   name: z.string().optional().describe("Optional text node name"),
-  parentId: figmaNodeId
+  parentId: createFigmaNodeIdSchema()
     .optional()
     .describe("Optional parent node ID to append the text into"),
   characters: z.string().optional().describe("Initial text content"),
@@ -390,7 +396,7 @@ export const createTextShape = z.object({
   textAutoResize: textAutoResize
     .optional()
     .describe("Optional text auto-resize mode"),
-  fillHex: hexColor.optional().describe("Optional text fill color as hex"),
+  fillHex: createHexColorSchema().optional().describe("Optional text fill color as hex"),
   fillOpacity: z
     .number()
     .min(0)
@@ -413,7 +419,7 @@ export const createTextInput = createTextShape
 export const createShapeShape = z.object({
   shapeType: shapeType.describe("Shape type to create"),
   name: z.string().optional().describe("Optional shape name"),
-  parentId: figmaNodeId
+  parentId: createFigmaNodeIdSchema()
     .optional()
     .describe("Optional parent node ID to append the shape into"),
   x: z.number().optional().describe("Optional x position"),
@@ -426,14 +432,14 @@ export const createShapeShape = z.object({
     .min(0)
     .optional()
     .describe("Optional corner radius for supported shapes"),
-  fillHex: hexColor.optional().describe("Optional fill color as hex"),
+  fillHex: createHexColorSchema().optional().describe("Optional fill color as hex"),
   fillOpacity: z
     .number()
     .min(0)
     .max(1)
     .optional()
     .describe("Optional fill opacity from 0 to 1"),
-  strokeHex: hexColor.optional().describe("Optional stroke color as hex"),
+  strokeHex: createHexColorSchema().optional().describe("Optional stroke color as hex"),
   strokeOpacity: z
     .number()
     .min(0)
@@ -474,7 +480,7 @@ export const createImageInput = z.object({
       "Image source. Accepts a local file path (absolute or relative to the MCP server cwd), an http/https URL, or a data URI."
     ),
   name: z.string().optional().describe("Optional image node name"),
-  parentId: figmaNodeId
+  parentId: createFigmaNodeIdSchema()
     .optional()
     .describe("Optional parent node ID to append the image into"),
   x: z.number().optional().describe("Optional x position"),
@@ -502,7 +508,7 @@ export const toolInputSchemas = {
   }),
 
   get_node: z.object({
-    nodeId: figmaNodeId.describe(
+    nodeId: createFigmaNodeIdSchema().describe(
       "The node ID to fetch. Accepts top-level IDs like '4029:12345' and instance-child IDs like 'I12740:17806;12740:17793'."
     ),
     fileKey: fileKeyField,
@@ -530,12 +536,12 @@ export const toolInputSchemas = {
 
   get_screenshot: z.object({
     nodeIds: z
-      .array(figmaNodeId)
+      .array(createFigmaNodeIdSchema())
       .optional()
       .describe(
         "Optional list of node IDs to export. Accepts top-level IDs like '4029:12345' and instance-child IDs like 'I12740:17806;12740:17793'. Never use hyphens. If empty, exports the current selection.",
       ),
-    format: exportFormat
+    format: createExportFormatSchema()
       .optional()
       .describe("Export format: PNG (default) or SVG or JPG or PDF"),
     scale: z
@@ -555,7 +561,7 @@ export const toolInputSchemas = {
     items: z
       .array(
         z.object({
-          nodeId: figmaNodeId.describe("The node ID to modify"),
+          nodeId: createFigmaNodeIdSchema().describe("The node ID to modify"),
           visible: z.boolean().describe("true to show, false to hide"),
         })
       )
@@ -565,7 +571,7 @@ export const toolInputSchemas = {
   }),
 
   set_text_content: z.object({
-    nodeId: figmaNodeId.describe("The text node ID to update"),
+    nodeId: createFigmaNodeIdSchema().describe("The text node ID to update"),
     text: z.string().describe("The new text content"),
     fileKey: fileKeyField,
   }),
@@ -633,7 +639,7 @@ export const toolInputSchemas = {
 
   duplicate_nodes: z.object({
     nodeIds: z
-      .array(figmaNodeId)
+      .array(createFigmaNodeIdSchema())
       .min(1)
       .describe("List of node IDs to duplicate"),
     fileKey: fileKeyField,
@@ -641,10 +647,10 @@ export const toolInputSchemas = {
 
   reparent_nodes: z.object({
     nodeIds: z
-      .array(figmaNodeId)
+      .array(createFigmaNodeIdSchema())
       .min(1)
       .describe("List of node IDs to move"),
-    parentId: figmaNodeId.describe("Destination parent node ID"),
+    parentId: createFigmaNodeIdSchema().describe("Destination parent node ID"),
     fileKey: fileKeyField,
   }),
 
@@ -658,7 +664,7 @@ export const toolInputSchemas = {
 
   delete_nodes: z.object({
     nodeIds: z
-      .array(figmaNodeId)
+      .array(createFigmaNodeIdSchema())
       .min(1)
       .describe("List of node IDs to delete"),
     confirm: z
@@ -671,7 +677,7 @@ export const toolInputSchemas = {
     items: z
       .array(
         z.object({
-          nodeId: figmaNodeId.describe(
+          nodeId: createFigmaNodeIdSchema().describe(
             "The node ID to export. Accepts top-level IDs like '4029:12345' and instance-child IDs like 'I12740:17806;12740:17793'."
           ),
           outputPath: z
@@ -680,7 +686,7 @@ export const toolInputSchemas = {
             .describe(
               "Output file path (relative paths resolve from the MCP server current working directory)",
             ),
-          format: exportFormat
+          format: createExportFormatSchema()
             .optional()
             .describe("Per-item export format override: PNG, SVG, JPG, or PDF"),
           scale: z
@@ -697,7 +703,7 @@ export const toolInputSchemas = {
       )
       .min(1)
       .describe("List of screenshot save operations to execute in batch"),
-    format: exportFormat
+    format: createExportFormatSchema()
       .optional()
       .describe("Default export format: PNG (default) or SVG or JPG or PDF"),
     scale: z

--- a/server/src/schema.ts
+++ b/server/src/schema.ts
@@ -53,10 +53,8 @@ const gradientStop = z.object({
 });
 
 const gradientTransform = z
-  .tuple([
-    z.tuple([z.number(), z.number(), z.number()]),
-    z.tuple([z.number(), z.number(), z.number()]),
-  ])
+  .array(z.array(z.number()).length(3))
+  .length(2)
   .describe(
     "2x3 affine matrix [[a,b,tx],[c,d,ty]] mapping the unit gradient onto the shape (Figma's gradientTransform). Defaults to identity (horizontal left→right)."
   );
@@ -178,6 +176,42 @@ const blurEffect = z.object({
   visible: z.boolean().optional().describe("Default true"),
 });
 
+const effectInput = z.object({
+  type: z
+    .enum(["DROP_SHADOW", "INNER_SHADOW", "LAYER_BLUR", "BACKGROUND_BLUR"])
+    .describe("Effect type"),
+  color: createHexColorSchema()
+    .optional()
+    .describe("Required for shadow effects"),
+  opacity: z
+    .number()
+    .min(0)
+    .max(1)
+    .optional()
+    .describe("Shadow alpha 0..1 (default 1)"),
+  offset: z
+    .object({
+      x: z.number(),
+      y: z.number(),
+    })
+    .optional()
+    .describe("Required for shadow effects"),
+  radius: z.number().min(0).optional().describe("Required blur radius"),
+  spread: z
+    .number()
+    .optional()
+    .describe(
+      "Expand/contract distance (default 0). Only honored on rects/ellipses, or on frames/components/instances with visible fills and clipsContent."
+    ),
+  blendMode: blendMode.optional().describe("Default NORMAL"),
+  visible: z.boolean().optional().describe("Default true"),
+});
+
+const effectRuntimeSchema = z.discriminatedUnion("type", [
+  shadowEffect,
+  blurEffect,
+]);
+
 export const setSelectionInput = z.object({
   nodeIds: z
     .array(createFigmaNodeIdSchema())
@@ -214,14 +248,28 @@ export const ungroupNodeInput = z.object({
   fileKey: fileKeyField,
 });
 
-export const setEffectsInput = z.object({
+export const setEffectsShape = z.object({
   nodeId: createFigmaNodeIdSchema().describe("The node ID to update"),
   effects: z
-    .array(z.discriminatedUnion("type", [shadowEffect, blurEffect]))
+    .array(effectInput)
     .describe(
       "Full replacement list of effects. Pass [] to clear all effects. Each entry is a drop/inner shadow or a layer/background blur."
     ),
   fileKey: fileKeyField,
+});
+
+export const setEffectsInput = setEffectsShape.superRefine((value, ctx) => {
+  value.effects.forEach((effect, index) => {
+    const result = effectRuntimeSchema.safeParse(effect);
+    if (result.success) return;
+
+    for (const issue of result.error.issues) {
+      ctx.addIssue({
+        ...issue,
+        path: ["effects", index, ...issue.path],
+      });
+    }
+  });
 });
 
 export const setStrokePropertiesInput = z.object({

--- a/server/src/schema.ts
+++ b/server/src/schema.ts
@@ -8,6 +8,11 @@ import { z } from "zod";
  * Both forms are valid for figma.getNodeById and are returned as-is by the plugin
  * from get_selection / get_design_context.
  */
+
+/**
+ * Creates a Zod schema that validates a Figma node ID string.
+ * @returns A Zod string schema for node IDs.
+ */
 const createFigmaNodeIdSchema = () => z
   .string()
   .regex(
@@ -15,11 +20,20 @@ const createFigmaNodeIdSchema = () => z
     "Node ID must use colon format, e.g. '4029:12345', or instance-child format 'I12740:17806;12740:17793'"
   );
 
+/** Shared Figma node ID schema for reuse in RPC validation. */
 export const figmaNodeId = createFigmaNodeIdSchema();
 
+/**
+ * Creates a Zod schema that validates a screenshot export format.
+ * @returns A Zod enum schema for export formats.
+ */
 const createExportFormatSchema = () => z.enum(["PNG", "SVG", "JPG", "PDF"]);
 const exportFormat = createExportFormatSchema();
 
+/**
+ * Creates a Zod schema that validates a CSS-style hex color string.
+ * @returns A Zod string schema for hex colors.
+ */
 const createHexColorSchema = () => z
   .string()
   .regex(/^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/, "Color must be a hex value like '#FFAA00'");

--- a/server/src/schema.ts
+++ b/server/src/schema.ts
@@ -13,34 +13,39 @@ import { z } from "zod";
  * Creates a Zod schema that validates a Figma node ID string.
  * @returns A Zod string schema for node IDs.
  */
-const createFigmaNodeIdSchema = () => z
-  .string()
-  .regex(
-    /^(\d+:\d+|I\d+:\d+(;\d+:\d+)+)$/,
-    "Node ID must use colon format, e.g. '4029:12345', or instance-child format 'I12740:17806;12740:17793'"
-  );
-
-/** Shared Figma node ID schema for reuse in RPC validation. */
-export const figmaNodeId = createFigmaNodeIdSchema();
+const createFigmaNodeIdSchema = () =>
+  z
+    .string()
+    .regex(
+      /^(\d+:\d+|I\d+:\d+(;\d+:\d+)+)$/,
+      "Node ID must use colon format, e.g. '4029:12345', or instance-child format 'I12740:17806;12740:17793'"
+    );
 
 /**
  * Creates a Zod schema that validates a screenshot export format.
  * @returns A Zod enum schema for export formats.
  */
 const createExportFormatSchema = () => z.enum(["PNG", "SVG", "JPG", "PDF"]);
-const exportFormat = createExportFormatSchema();
 
 /**
  * Creates a Zod schema that validates a CSS-style hex color string.
  * @returns A Zod string schema for hex colors.
  */
-const createHexColorSchema = () => z
-  .string()
-  .regex(/^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/, "Color must be a hex value like '#FFAA00'");
-const hexColor = createHexColorSchema();
+const createHexColorSchema = () =>
+  z
+    .string()
+    .regex(
+      /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/,
+      "Color must be a hex value like '#FFAA00'"
+    );
 const textAlignHorizontal = z.enum(["LEFT", "CENTER", "RIGHT", "JUSTIFIED"]);
 const textAlignVertical = z.enum(["TOP", "CENTER", "BOTTOM"]);
-const textAutoResize = z.enum(["NONE", "WIDTH_AND_HEIGHT", "HEIGHT", "TRUNCATE"]);
+const textAutoResize = z.enum([
+  "NONE",
+  "WIDTH_AND_HEIGHT",
+  "HEIGHT",
+  "TRUNCATE",
+]);
 const shapeType = z.enum(["RECTANGLE", "ELLIPSE", "LINE"]);
 const imageScaleMode = z.enum(["FILL", "FIT"]);
 
@@ -112,11 +117,7 @@ export const setNodePropertiesInput = z.object({
     .optional()
     .describe("Optional opacity from 0 to 1"),
   visible: z.boolean().optional().describe("Optional visibility"),
-  cornerRadius: z
-    .number()
-    .min(0)
-    .optional()
-    .describe("Optional corner radius"),
+  cornerRadius: z.number().min(0).optional().describe("Optional corner radius"),
   fileKey: fileKeyField,
 });
 
@@ -304,13 +305,7 @@ export const setStrokePropertiesInput = z.object({
       "Dash pattern as [dash, gap, dash, gap, ...] in pixels. Pass [] for a solid stroke."
     ),
   strokeCap: z
-    .enum([
-      "NONE",
-      "ROUND",
-      "SQUARE",
-      "ARROW_LINES",
-      "ARROW_EQUILATERAL",
-    ])
+    .enum(["NONE", "ROUND", "SQUARE", "ARROW_LINES", "ARROW_EQUILATERAL"])
     .optional()
     .describe("End-cap style (only meaningful on open paths/lines)"),
   strokeJoin: z
@@ -321,7 +316,9 @@ export const setStrokePropertiesInput = z.object({
 });
 
 export const setAutoLayoutInput = z.object({
-  nodeId: createFigmaNodeIdSchema().describe("The node ID to update (must be a frame)"),
+  nodeId: createFigmaNodeIdSchema().describe(
+    "The node ID to update (must be a frame)"
+  ),
   layoutMode: z
     .enum(["NONE", "HORIZONTAL", "VERTICAL"])
     .optional()
@@ -405,7 +402,9 @@ export const setTextPropertiesShape = z.object({
     .number()
     .optional()
     .describe("Optional letter spacing in pixels"),
-  fillHex: createHexColorSchema().optional().describe("Optional text fill color as hex"),
+  fillHex: createHexColorSchema()
+    .optional()
+    .describe("Optional text fill color as hex"),
   fillOpacity: z
     .number()
     .min(0)
@@ -436,11 +435,11 @@ export const setTextPropertiesInput = setTextPropertiesShape
       value.y !== undefined ||
       value.width !== undefined ||
       value.height !== undefined,
-    "At least one text property must be provided",
+    "At least one text property must be provided"
   )
   .refine(
     (value) => value.fillOpacity === undefined || value.fillHex !== undefined,
-    "fillHex is required when fillOpacity is provided",
+    "fillHex is required when fillOpacity is provided"
   );
 
 export const createTextShape = z.object({
@@ -458,7 +457,9 @@ export const createTextShape = z.object({
   textAutoResize: textAutoResize
     .optional()
     .describe("Optional text auto-resize mode"),
-  fillHex: createHexColorSchema().optional().describe("Optional text fill color as hex"),
+  fillHex: createHexColorSchema()
+    .optional()
+    .describe("Optional text fill color as hex"),
   fillOpacity: z
     .number()
     .min(0)
@@ -472,11 +473,10 @@ export const createTextShape = z.object({
   fileKey: fileKeyField,
 });
 
-export const createTextInput = createTextShape
-  .refine(
-    (value) => value.fillOpacity === undefined || value.fillHex !== undefined,
-    "fillHex is required when fillOpacity is provided",
-  );
+export const createTextInput = createTextShape.refine(
+  (value) => value.fillOpacity === undefined || value.fillHex !== undefined,
+  "fillHex is required when fillOpacity is provided"
+);
 
 export const createShapeShape = z.object({
   shapeType: shapeType.describe("Shape type to create"),
@@ -494,14 +494,18 @@ export const createShapeShape = z.object({
     .min(0)
     .optional()
     .describe("Optional corner radius for supported shapes"),
-  fillHex: createHexColorSchema().optional().describe("Optional fill color as hex"),
+  fillHex: createHexColorSchema()
+    .optional()
+    .describe("Optional fill color as hex"),
   fillOpacity: z
     .number()
     .min(0)
     .max(1)
     .optional()
     .describe("Optional fill opacity from 0 to 1"),
-  strokeHex: createHexColorSchema().optional().describe("Optional stroke color as hex"),
+  strokeHex: createHexColorSchema()
+    .optional()
+    .describe("Optional stroke color as hex"),
   strokeOpacity: z
     .number()
     .min(0)
@@ -519,19 +523,20 @@ export const createShapeShape = z.object({
 export const createShapeInput = createShapeShape
   .refine(
     (value) => value.fillOpacity === undefined || value.fillHex !== undefined,
-    "fillHex is required when fillOpacity is provided",
+    "fillHex is required when fillOpacity is provided"
   )
   .refine(
-    (value) => value.strokeOpacity === undefined || value.strokeHex !== undefined,
-    "strokeHex is required when strokeOpacity is provided",
+    (value) =>
+      value.strokeOpacity === undefined || value.strokeHex !== undefined,
+    "strokeHex is required when strokeOpacity is provided"
   )
   .refine(
     (value) => value.shapeType !== "LINE" || value.fillHex === undefined,
-    "LINE shapes do not support fillHex — use strokeHex instead",
+    "LINE shapes do not support fillHex — use strokeHex instead"
   )
   .refine(
     (value) => value.shapeType !== "LINE" || value.strokeHex !== undefined,
-    "LINE shapes require strokeHex (lines have no fill and would be invisible otherwise)",
+    "LINE shapes require strokeHex (lines have no fill and would be invisible otherwise)"
   );
 
 export const createImageInput = z.object({
@@ -549,11 +554,7 @@ export const createImageInput = z.object({
   y: z.number().optional().describe("Optional y position"),
   width: z.number().positive().optional().describe("Optional width"),
   height: z.number().positive().optional().describe("Optional height"),
-  cornerRadius: z
-    .number()
-    .min(0)
-    .optional()
-    .describe("Optional corner radius"),
+  cornerRadius: z.number().min(0).optional().describe("Optional corner radius"),
   scaleMode: imageScaleMode
     .optional()
     .describe("How the image should fit its bounds: FILL (default) or FIT"),
@@ -601,7 +602,7 @@ export const toolInputSchemas = {
       .array(createFigmaNodeIdSchema())
       .optional()
       .describe(
-        "Optional list of node IDs to export. Accepts top-level IDs like '4029:12345' and instance-child IDs like 'I12740:17806;12740:17793'. Never use hyphens. If empty, exports the current selection.",
+        "Optional list of node IDs to export. Accepts top-level IDs like '4029:12345' and instance-child IDs like 'I12740:17806;12740:17793'. Never use hyphens. If empty, exports the current selection."
       ),
     format: createExportFormatSchema()
       .optional()
@@ -614,7 +615,7 @@ export const toolInputSchemas = {
       .boolean()
       .optional()
       .describe(
-        "When true, export using Figma's absolute node bounds (REST use_absolute_bounds / plugin useAbsoluteBounds) so PNGs are clipped to the node's logical bounds",
+        "When true, export using Figma's absolute node bounds (REST use_absolute_bounds / plugin useAbsoluteBounds) so PNGs are clipped to the node's logical bounds"
       ),
     fileKey: fileKeyField,
   }),
@@ -684,14 +685,13 @@ export const toolInputSchemas = {
       value.opacity !== undefined ||
       value.visible !== undefined ||
       value.cornerRadius !== undefined,
-    "At least one property must be provided",
+    "At least one property must be provided"
   ),
 
-  create_frame: createFrameInput
-    .refine(
-      (value) => value.fillOpacity === undefined || value.fillHex !== undefined,
-      "fillHex is required when fillOpacity is provided",
-    ),
+  create_frame: createFrameInput.refine(
+    (value) => value.fillOpacity === undefined || value.fillHex !== undefined,
+    "fillHex is required when fillOpacity is provided"
+  ),
 
   create_text: createTextInput,
 
@@ -729,9 +729,7 @@ export const toolInputSchemas = {
       .array(createFigmaNodeIdSchema())
       .min(1)
       .describe("List of node IDs to delete"),
-    confirm: z
-      .boolean()
-      .describe("Must be true to confirm deletion"),
+    confirm: z.boolean().describe("Must be true to confirm deletion"),
     fileKey: fileKeyField,
   }),
 
@@ -746,7 +744,7 @@ export const toolInputSchemas = {
             .string()
             .min(1)
             .describe(
-              "Output file path (relative paths resolve from the MCP server current working directory)",
+              "Output file path (relative paths resolve from the MCP server current working directory)"
             ),
           format: createExportFormatSchema()
             .optional()
@@ -759,9 +757,9 @@ export const toolInputSchemas = {
             .boolean()
             .optional()
             .describe(
-              "Per-item clipping override. When true, PNGs are clipped to the node's logical bounds using Figma's absolute node bounds.",
+              "Per-item clipping override. When true, PNGs are clipped to the node's logical bounds using Figma's absolute node bounds."
             ),
-        }),
+        })
       )
       .min(1)
       .describe("List of screenshot save operations to execute in batch"),
@@ -776,7 +774,7 @@ export const toolInputSchemas = {
       .boolean()
       .optional()
       .describe(
-        "Default clipping behavior for saved screenshots. When true, PNGs are clipped to the node's logical bounds using Figma's absolute node bounds.",
+        "Default clipping behavior for saved screenshots. When true, PNGs are clipped to the node's logical bounds using Figma's absolute node bounds."
       ),
     fileKey: fileKeyField,
   }),
@@ -803,12 +801,21 @@ const rpcToArgs: Record<
   get_screenshot: (nodeIds, params) => ({ nodeIds, ...params }),
   set_node_visibility: (_nodeIds, params) => ({ ...params }),
   set_text_content: (nodeIds, params) => ({ ...params, nodeId: nodeIds?.[0] }),
-  set_text_properties: (nodeIds, params) => ({ ...params, nodeId: nodeIds?.[0] }),
-  set_node_properties: (nodeIds, params) => ({ ...params, nodeId: nodeIds?.[0] }),
+  set_text_properties: (nodeIds, params) => ({
+    ...params,
+    nodeId: nodeIds?.[0],
+  }),
+  set_node_properties: (nodeIds, params) => ({
+    ...params,
+    nodeId: nodeIds?.[0],
+  }),
   set_gradient_fill: (nodeIds, params) => ({ ...params, nodeId: nodeIds?.[0] }),
   set_solid_fill: (nodeIds, params) => ({ ...params, nodeId: nodeIds?.[0] }),
   set_effects: (nodeIds, params) => ({ ...params, nodeId: nodeIds?.[0] }),
-  set_stroke_properties: (nodeIds, params) => ({ ...params, nodeId: nodeIds?.[0] }),
+  set_stroke_properties: (nodeIds, params) => ({
+    ...params,
+    nodeId: nodeIds?.[0],
+  }),
   set_auto_layout: (nodeIds, params) => ({ ...params, nodeId: nodeIds?.[0] }),
   create_frame: (_nodeIds, params) => ({ ...params }),
   create_text: (_nodeIds, params) => ({ ...params }),
@@ -831,13 +838,13 @@ const rpcToArgs: Record<
 export function validateRpc(
   tool: string,
   nodeIds?: string[],
-  params?: Record<string, unknown>,
+  params?: Record<string, unknown>
 ): string | null {
   if (!(tool in toolInputSchemas)) return null;
 
   const name = tool as ToolName;
   const result = toolInputSchemas[name].safeParse(
-    rpcToArgs[name](nodeIds, params),
+    rpcToArgs[name](nodeIds, params)
   );
   return result.success ? null : result.error.issues[0].message;
 }

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -79,6 +79,12 @@ interface SaveScreenshotItemResult {
   error?: string;
 }
 
+/**
+ * Registers all Figma bridge tools on the given MCP server.
+ * @param server - The MCP server instance.
+ * @param node - The node coordinator for leader/follower routing.
+ * @param port - The port used for follower-to-leader HTTP calls.
+ */
 export function registerTools(
   server: McpServer,
   node: Node,
@@ -528,6 +534,15 @@ export function registerTools(
   );
 }
 
+/**
+ * Saves screenshots for multiple nodes to the local filesystem in batch.
+ * @param sender - Sender that forwards get_screenshot requests to the plugin.
+ * @param items - Screenshot save operations to execute.
+ * @param format - Default export format override.
+ * @param scale - Default export scale override for raster formats.
+ * @param clip - Default clipping override for saved screenshots.
+ * @returns Aggregate result with per-item outcomes.
+ */
 export async function executeSaveScreenshots(
   sender: ScreenshotSender,
   items: SaveScreenshotItemInput[],
@@ -568,6 +583,11 @@ export async function executeSaveScreenshots(
   };
 }
 
+/**
+ * Wraps a bridge call and converts the result into a tool result.
+ * @param fn - Bridge call to execute.
+ * @returns Tool result with the bridge response or an error message.
+ */
 async function renderResponse(
   fn: () => Promise<BridgeResponse>
 ): Promise<ToolResult> {
@@ -595,6 +615,12 @@ async function renderResponse(
   }
 }
 
+/**
+ * Parses raw tool arguments with a Zod schema and returns a typed result or a tool error.
+ * @param schema - Zod schema to validate against.
+ * @param args - Raw arguments from the MCP client.
+ * @returns Parsed data on success, or an error tool result on failure.
+ */
 function parseToolInput<T>(
   schema: z.ZodType<T>,
   args: unknown
@@ -613,6 +639,12 @@ function parseToolInput<T>(
   };
 }
 
+/**
+ * Resolves an output path relative to the workspace and ensures it stays inside it.
+ * @param outputPath - Relative or absolute output path.
+ * @param workspaceRoot - Root directory that must contain the resolved path.
+ * @returns Absolute path inside the workspace root.
+ */
 function resolveAndValidateOutputPath(
   outputPath: string,
   workspaceRoot: string
@@ -630,6 +662,12 @@ function resolveAndValidateOutputPath(
   return resolvedPath;
 }
 
+/**
+ * Loads an image source as a base64 string from a URL, data URI, or local file.
+ * @param source - Image source: URL, data URI, or local file path.
+ * @param workspaceRoot - Root directory for resolving relative local paths.
+ * @returns Base64-encoded image bytes.
+ */
 async function loadImageSourceAsBase64(
   source: string,
   workspaceRoot: string
@@ -661,6 +699,11 @@ async function loadImageSourceAsBase64(
   return bytes.toString("base64");
 }
 
+/**
+ * Fetches image bytes from a remote URL with redirect and timeout limits.
+ * @param source - HTTP or HTTPS image URL.
+ * @returns Raw image bytes.
+ */
 async function fetchImageBytes(source: string): Promise<Buffer> {
   let url = new URL(source);
   let redirects = 0;
@@ -728,6 +771,10 @@ async function fetchImageBytes(source: string): Promise<Buffer> {
   }
 }
 
+/**
+ * Validates that an image URL uses a safe public HTTP(S) endpoint.
+ * @param url - URL to validate.
+ */
 async function assertSafeHttpUrl(url: URL): Promise<void> {
   if (url.protocol !== "http:" && url.protocol !== "https:") {
     throw new Error("Image URL must use http or https");
@@ -754,6 +801,11 @@ async function assertSafeHttpUrl(url: URL): Promise<void> {
   }
 }
 
+/**
+ * Checks whether an IP address is in a private, loopback, or otherwise blocked range.
+ * @param address - IPv4 or IPv6 address string.
+ * @returns True if the address is blocked for SSRF protection.
+ */
 function isBlockedIp(address: string): boolean {
   if (isIP(address) === 4) {
     const [a, b] = address.split(".").map(Number);
@@ -784,6 +836,11 @@ function isBlockedIp(address: string): boolean {
   );
 }
 
+/**
+ * Strips surrounding brackets from an IPv6 hostname so it can be parsed as an IP.
+ * @param hostname - Hostname string, possibly bracketed.
+ * @returns Normalized hostname without brackets.
+ */
 function normalizeHostname(hostname: string): string {
   if (hostname.startsWith("[") && hostname.endsWith("]")) {
     return hostname.slice(1, -1);
@@ -791,6 +848,12 @@ function normalizeHostname(hostname: string): string {
   return hostname;
 }
 
+/**
+ * Reads a response body up to a maximum byte limit.
+ * @param resp - Fetch response with a readable body.
+ * @param maxBytes - Maximum number of bytes to accept.
+ * @returns Concatenated response bytes.
+ */
 async function readBoundedResponse(
   resp: Response,
   maxBytes: number
@@ -812,6 +875,11 @@ async function readBoundedResponse(
   return Buffer.concat(chunks, total);
 }
 
+/**
+ * Infers an export format from a file path extension.
+ * @param outputPath - Output file path.
+ * @returns Export format, or null if the extension is unrecognized.
+ */
 function inferFormatFromPath(outputPath: string): ExportFormat | null {
   const ext = path.extname(outputPath).toLowerCase();
   switch (ext) {
@@ -829,6 +897,12 @@ function inferFormatFromPath(outputPath: string): ExportFormat | null {
   }
 }
 
+/**
+ * Resolves the final export format, ensuring it does not conflict with the file extension.
+ * @param format - Explicitly requested format.
+ * @param inferredFormat - Format inferred from the output path extension.
+ * @returns Resolved export format.
+ */
 function resolveExportFormat(
   format: ExportFormat | undefined,
   inferredFormat: ExportFormat | null
@@ -841,6 +915,11 @@ function resolveExportFormat(
   return format ?? inferredFormat ?? "PNG";
 }
 
+/**
+ * Extracts and validates the first screenshot export from plugin response data.
+ * @param data - Plugin response payload.
+ * @returns Validated screenshot export object.
+ */
 function getSingleScreenshotExport(data: unknown): ScreenshotExport {
   if (!data || typeof data !== "object") {
     throw new Error("Invalid screenshot response from plugin");
@@ -868,6 +947,17 @@ function getSingleScreenshotExport(data: unknown): ScreenshotExport {
   return screenshot;
 }
 
+/**
+ * Saves a single screenshot item to the local filesystem.
+ * @param sender - Sender that forwards get_screenshot requests to the plugin.
+ * @param item - Screenshot save request.
+ * @param index - Index of this item in the batch.
+ * @param workspaceRoot - Root directory for resolving output paths.
+ * @param defaultFormat - Default export format override.
+ * @param defaultScale - Default export scale override.
+ * @param defaultClip - Default clipping override.
+ * @returns Result of the save operation.
+ */
 async function saveScreenshotItemToFile(
   sender: ScreenshotSender,
   item: SaveScreenshotItemInput,
@@ -937,6 +1027,12 @@ async function saveScreenshotItemToFile(
   }
 }
 
+/**
+ * Writes base64-encoded bytes to a file, creating parent directories as needed.
+ * @param base64 - Base64-encoded file contents.
+ * @param outputPath - Destination file path.
+ * @returns Number of bytes written.
+ */
 async function writeBase64ToFile(
   base64: string,
   outputPath: string
@@ -954,6 +1050,12 @@ async function writeBase64ToFile(
   return bytes.length;
 }
 
+/**
+ * Resolves the effective screenshot scale from item and default values.
+ * @param itemScale - Scale specified for the item.
+ * @param defaultScale - Default scale for the batch.
+ * @returns Positive scale value, or undefined if not applicable.
+ */
 function resolveScale(
   itemScale?: number,
   defaultScale?: number
@@ -965,6 +1067,11 @@ function resolveScale(
   return resolvedScale;
 }
 
+/**
+ * Type guard that checks whether a value is a NodeJS error with an optional code.
+ * @param err - Value to check.
+ * @returns True when the value is an Error instance.
+ */
 function isNodeError(err: unknown): err is NodeJS.ErrnoException {
   return err instanceof Error;
 }

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -15,6 +15,7 @@ import {
   setNodePropertiesInput,
   setGradientFillInput,
   setSolidFillInput,
+  setEffectsShape,
   setEffectsInput,
   setStrokePropertiesInput,
   setAutoLayoutInput,
@@ -293,8 +294,11 @@ export function registerTools(
   server.tool(
     "set_effects",
     "Replace a node's effects list (drop/inner shadows, layer/background blurs). Pass an empty array to clear all effects. Each entry mirrors the shape returned by get_node's `effects` field.",
-    setEffectsInput.shape,
-    async ({ nodeId, fileKey, ...params }): Promise<ToolResult> => {
+    setEffectsShape.shape,
+    async (args): Promise<ToolResult> => {
+      const parsed = parseToolInput(setEffectsInput, args);
+      if (!parsed.success) return parsed.error;
+      const { nodeId, fileKey, ...params } = parsed.data;
       return renderResponse(() =>
         node.sendWithParams("set_effects", [nodeId], params, fileKey)
       );


### PR DESCRIPTION
Provider compatibility: resolves an issue where the repeated instances of Zod schemas produce incompatible MCP tool schemas, causing Moonshot AI to fail.

This issue can cause Moonshot to fail when the Figma MCP Bridge is enabled, with the following error message:

Invalid request: tools.function.parameters is not a valid moonshot flavored json schema
At path 'properties.strokeHex.$ref': references must start with #/$defs/

CAUSE:
Reusuable Zod schemas like hexColor, figmaNodeId, and exportFormat, were reused in multiple inputs to the public MCP tool input schema fields. The MCP SDK generates JSONSchema from the Zod schemas to use in tool definitions. However, the current path for Zod v3 / zod-to-json-schema is generating repeated $ref values such as #/properties/fillHex, which are rejected by Moonshot as it only accepts #/$defs/ values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized creation of node ID, color, and screenshot export-format validation across tools to use consistent, fresh schema instances.
  * Updated gradient transform validation to match an array-based affine matrix shape.
* **Bug Fixes**
  * Improved validation for per-effect entries and gradient transforms, with more precise error mapping to the relevant effect item.
* **Chores**
  * The effects tool now validates and parses its input payload before execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->