### PR TITLE
[codex] Fix create_image follower RPC validation

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -12,6 +12,7 @@
   ],
   "scripts": {
     "build": "tsc",
+    "test": "npm run build && node --test test/create-image-rpc.test.mjs",
     "prepublishOnly": "bun run build"
   },
   "keywords": [

--- a/server/src/follower.ts
+++ b/server/src/follower.ts
@@ -32,11 +32,13 @@ export class Follower {
       signal: AbortSignal.timeout(35_000),
     });
 
-    if (!response.ok) {
-      throw new Error(`Leader returned status ${response.status}`);
-    }
-
     const rpcResp = (await response.json()) as RPCResponse;
+
+    if (!response.ok) {
+      throw new Error(
+        rpcResp.error ?? `Leader returned status ${response.status}`
+      );
+    }
 
     if (rpcResp.error) {
       throw new Error(rpcResp.error);
@@ -57,11 +59,13 @@ export class Follower {
       signal: AbortSignal.timeout(5_000),
     });
 
-    if (!response.ok) {
-      throw new Error(`Leader returned status ${response.status}`);
-    }
-
     const rpcResp = (await response.json()) as RPCResponse;
+
+    if (!response.ok) {
+      throw new Error(
+        rpcResp.error ?? `Leader returned status ${response.status}`
+      );
+    }
     if (rpcResp.error) {
       throw new Error(rpcResp.error);
     }

--- a/server/src/schema.ts
+++ b/server/src/schema.ts
@@ -561,6 +561,15 @@ export const createImageInput = z.object({
   fileKey: fileKeyField,
 });
 
+// create_image resolves `source` inside the follower process before forwarding
+// the request. The leader therefore receives imageBase64 rather than the
+// public MCP input shape above.
+const createImageRpcInput = createImageInput
+  .omit({ source: true, fileKey: true })
+  .extend({
+    imageBase64: z.string().min(1),
+  });
+
 export const toolInputSchemas = {
   get_document: z.object({
     fileKey: fileKeyField,
@@ -782,6 +791,11 @@ export const toolInputSchemas = {
 
 type ToolName = keyof typeof toolInputSchemas;
 
+const rpcInputSchemas = {
+  ...toolInputSchemas,
+  create_image: createImageRpcInput,
+} as const;
+
 /**
  * Maps the RPC wire format { tool, nodeIds?, params? } to each tool's
  * expected input shape. Typed as Record<ToolName, ...> so adding a schema
@@ -843,7 +857,7 @@ export function validateRpc(
   if (!(tool in toolInputSchemas)) return null;
 
   const name = tool as ToolName;
-  const result = toolInputSchemas[name].safeParse(
+  const result = rpcInputSchemas[name].safeParse(
     rpcToArgs[name](nodeIds, params)
   );
   return result.success ? null : result.error.issues[0].message;

--- a/server/test/create-image-rpc.test.mjs
+++ b/server/test/create-image-rpc.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import test from "node:test";
+import { Follower } from "../dist/follower.js";
+import { validateRpc } from "../dist/schema.js";
+
+test("create_image validates the internal base64 RPC payload", () => {
+  assert.equal(
+    validateRpc("create_image", undefined, {
+      imageBase64: "AA==",
+      name: "Test image",
+    }),
+    null
+  );
+  assert.notEqual(
+    validateRpc("create_image", undefined, { name: "Test image" }),
+    null
+  );
+});
+
+test("follower exposes validation errors returned by the leader", async () => {
+  const server = http.createServer((_req, res) => {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "imageBase64 is required" }));
+  });
+
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+
+  try {
+    const follower = new Follower(`http://127.0.0.1:${address.port}`);
+    await assert.rejects(
+      follower.sendWithParams("create_image"),
+      new Error("imageBase64 is required")
+    );
+  } finally {
+    await new Promise((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve()))
+    );
+  }
+});


### PR DESCRIPTION
## Summary

- validate `create_image` follower RPCs against their internal `imageBase64` payload
- surface validation errors returned by the leader instead of only reporting HTTP 400
- add regression coverage for follower payload validation and error propagation

## Root cause

The follower resolves the public `source` argument to `imageBase64` before forwarding the request. The leader then validated that internal request with the public `createImageInput` schema, which still required `source`, so valid follower calls were rejected with HTTP 400.

## Impact

`create_image` now works when the calling MCP process is a follower, and future leader-side validation errors remain actionable.

## Validation

- `npm test`
- 2 tests passed
- TypeScript build passed

Fixes #35