### PR TITLE
fix(schema): accept resolved imageBase64 on create_image RPC path

### DIFF
--- a/server/src/schema.ts
+++ b/server/src/schema.ts
@@ -561,6 +561,32 @@ export const createImageInput = z.object({
   fileKey: fileKeyField,
 });
 
+/**
+ * Wire shape for create_image on the follower -> leader RPC path.
+ *
+ * The tool handler resolves `source` (file path / URL / data URI) into
+ * `imageBase64` before sending, so the payload reaching `validateRpc` carries
+ * `imageBase64` and no `source`. Validating that against `createImageInput`
+ * failed every follower call with "Leader returned status 400".
+ *
+ * `source` stays accepted so a leader running an older server build — which
+ * still forwards the unresolved source — keeps validating.
+ */
+export const createImageWireInput = createImageInput
+  .omit({ source: true })
+  .extend({
+    source: createImageInput.shape.source.optional(),
+    imageBase64: z
+      .string()
+      .min(1)
+      .optional()
+      .describe("Base64 image payload resolved from source by the MCP server"),
+  })
+  .refine(
+    (value) => value.imageBase64 !== undefined || value.source !== undefined,
+    "Either source or imageBase64 is required"
+  );
+
 export const toolInputSchemas = {
   get_document: z.object({
     fileKey: fileKeyField,
@@ -697,7 +723,7 @@ export const toolInputSchemas = {
 
   create_shape: createShapeInput,
 
-  create_image: createImageInput,
+  create_image: createImageWireInput,
 
   duplicate_nodes: z.object({
     nodeIds: z


### PR DESCRIPTION
## Problem

`create_image` resolves `source` into `imageBase64` inside the tool handler, then forwards the **resolved** payload to the bridge:

```ts
async ({ source, fileKey, ...params }) => {
  const imageBase64 = await loadImageSourceAsBase64(source, process.cwd());
  return await renderResponse(() =>
    node.sendWithParams("create_image", undefined, { ...params, imageBase64 }, fileKey)
  );
}
```

`source` is destructured out, so what reaches the leader is `{ ...params, imageBase64 }` — no `source`.

But the RPC path validates against `createImageInput`:

```ts
create_image: createImageInput,   // requires `source`, doesn't know `imageBase64`
```

So `validateRpc` rejects the request before it ever reaches the plugin.

**Effect:** `create_image` fails on every follower with `Leader returned status 400` as soon as a second session holds the bridge. Leader-only setups are unaffected, which is why this stays hidden in single-session use — I only hit it because I had two Claude Code sessions open against the same file.

Reproduced against `main`:

```js
validateRpc("create_image", undefined,
            { imageBase64: "iVBORw0KGgo=", parentId: "1:2", width: 30 })
// → "Required"     ← the rejection behind the 400
```

## Fix

Validate the RPC path against the wire shape rather than the tool-input shape.

`source` is kept, but optional — a leader running an **older** server build still forwards the unresolved `source`, and rejecting that would just move the breakage to the other side of a version skew. At least one of the two is required; every other field is untouched.

```js
// after
{ imageBase64: "..." }                  → OK   (current wire format)
{ source: "/tmp/a.png" }                → OK   (older leader)
{ source: "...", imageBase64: "..." }   → OK
{ parentId: "1:2" }                     → rejected: "Either source or imageBase64 is required"
```

## Testing

`tsc --noEmit` passes.

Before/after on the exact failing payload:

```
before patch:  已复现 → validateRpc 拒绝，返回: "Required"
after  patch:  未复现（校验通过）
```

Schema-level:

```
PASS  imageBase64 (current wire format)
PASS  source (older leader)
PASS  both supplied
PASS  neither -> rejected: "Either source or imageBase64 is required"
PASS  empty imageBase64 -> rejected
PASS  malformed parentId -> still rejected
PASS  negative width -> still rejected

regression:
PASS  create_shape unaffected
PASS  create_frame unaffected
```

End-to-end: with the patched build the image lands in Figma; against the unpatched leader the same call returns `Leader returned status 400`.

## Note

Same class of issue as #39 — the payload on the wire doesn't match the schema that validates it. Happy to fold them together, or to take a different approach (e.g. keeping `source` in the forwarded params) if you'd prefer that shape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image creation requests can now provide image data directly as Base64, in addition to a source reference.
  * Requests remain validated to ensure at least one image input is supplied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->