### PR TITLE
feat: add create_page MCP tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ If you want to know more about how it works, read the [How it works](#how-it-wor
 | `set_effects` | Replace a node's effects list (drop/inner shadows, layer/background blurs) |
 | `set_stroke_properties` | Patch stroke weight, align, dash pattern, cap, and join |
 | `set_auto_layout` | Configure auto-layout direction, padding, gap, alignment, sizing, and wrap |
+| `create_page` | Create a new page in the document, optionally switching to it |
 | `create_frame` | Create a new frame, optionally under a parent |
 | `create_text` | Create a new text node |
 | `create_shape` | Create a rectangle, ellipse, or line |
@@ -113,6 +114,7 @@ All tools accept an optional `fileKey` parameter when multiple Figma files are c
 - Text edits automatically load the fonts currently used by the target text node before applying the new content.
 - New text nodes default to `Inter Regular` unless a font is provided.
 - `create_image` reads local paths relative to the MCP server working directory unless you pass an absolute path.
+- `create_page` returns the new page's ID — pass it as `parentId` to `create_frame` / `create_text` / `create_shape` / `create_image` to author content on that page without switching the editor.
 
 ### What You Can Build
 

--- a/plugin/src/main/code.ts
+++ b/plugin/src/main/code.ts
@@ -168,6 +168,12 @@ const getParentNodeById = async (
   if (!parent || parent.type === "DOCUMENT" || !supportsChildren(parent)) {
     throw new Error(`Parent does not support children: ${parentId}`);
   }
+  // Under `documentAccess: "dynamic-page"` a page's children are inaccessible
+  // until the page is explicitly loaded, so every caller would otherwise have
+  // to guard before appending.
+  if (parent.type === "PAGE") {
+    await parent.loadAsync();
+  }
   return parent;
 };
 
@@ -331,9 +337,6 @@ const appendToParentIfProvided = async (
     return;
   }
   const parent = await getParentNodeById(parentId);
-  if (parent.type === "PAGE") {
-    await (parent as PageNode).loadAsync();
-  }
   parent.appendChild(node);
 };
 

--- a/plugin/src/main/code.ts
+++ b/plugin/src/main/code.ts
@@ -18,6 +18,7 @@ type RequestType =
   | "set_effects"
   | "set_stroke_properties"
   | "set_auto_layout"
+  | "create_page"
   | "create_frame"
   | "create_text"
   | "create_shape"
@@ -354,6 +355,7 @@ const EDIT_REQUEST_TYPES = new Set<RequestType>([
   "set_effects",
   "set_stroke_properties",
   "set_auto_layout",
+  "create_page",
   "create_frame",
   "create_text",
   "create_shape",
@@ -1243,6 +1245,32 @@ const handleRequest = async (
             nodeId: node.id,
             nodeName: node.name,
             applied,
+          },
+        };
+      }
+      case "create_page": {
+        const params = request.params ?? {};
+        const page = figma.createPage();
+
+        if (typeof params.name === "string") {
+          page.name = params.name;
+        }
+
+        // The document is loaded with `documentAccess: "dynamic-page"`, so the
+        // page must be switched with the async setter — assigning
+        // `figma.currentPage` directly throws there.
+        if (params.setAsCurrent === true) {
+          await figma.setCurrentPageAsync(page);
+        }
+
+        return {
+          type: request.type,
+          requestId: request.requestId,
+          data: {
+            pageId: page.id,
+            pageName: page.name,
+            index: figma.root.children.indexOf(page),
+            isCurrentPage: figma.currentPage.id === page.id,
           },
         };
       }

--- a/plugin/src/main/code.ts
+++ b/plugin/src/main/code.ts
@@ -212,7 +212,9 @@ const setSolidFill = (
     if (!("strokes" in node)) {
       throw new Error(`Node does not support strokes: ${node.id}`);
     }
-    (node as GeometryMixin & { strokes: ReadonlyArray<Paint> }).strokes = [paint];
+    (node as GeometryMixin & { strokes: ReadonlyArray<Paint> }).strokes = [
+      paint,
+    ];
     return;
   }
 
@@ -271,7 +273,9 @@ const loadFontsForTextNode = async (node: TextNode): Promise<void> => {
     );
   }
 
-  await Promise.all([...fonts.values()].map((font) => figma.loadFontAsync(font)));
+  await Promise.all(
+    [...fonts.values()].map((font) => figma.loadFontAsync(font))
+  );
 };
 
 const ensureFont = async (family: string, style: string): Promise<FontName> => {
@@ -294,11 +298,7 @@ const applyTextFill = (
   ];
 };
 
-const positionNode = (
-  node: SceneNode,
-  x: unknown,
-  y: unknown
-): void => {
+const positionNode = (node: SceneNode, x: unknown, y: unknown): void => {
   if ("x" in node && typeof x === "number") {
     node.x = x;
   }
@@ -312,10 +312,7 @@ const resizeNodeIfSupported = (
   width: unknown,
   height: unknown
 ): void => {
-  if (
-    typeof width !== "number" &&
-    typeof height !== "number"
-  ) {
+  if (typeof width !== "number" && typeof height !== "number") {
     return;
   }
   if (!("resize" in node) || typeof node.resize !== "function") {
@@ -334,6 +331,9 @@ const appendToParentIfProvided = async (
     return;
   }
   const parent = await getParentNodeById(parentId);
+  if (parent.type === "PAGE") {
+    await (parent as PageNode).loadAsync();
+  }
   parent.appendChild(node);
 };
 
@@ -727,7 +727,10 @@ const handleRequest = async (
 
         await loadFontsForTextNode(node);
 
-        if (typeof params.fontFamily === "string" || typeof params.fontStyle === "string") {
+        if (
+          typeof params.fontFamily === "string" ||
+          typeof params.fontStyle === "string"
+        ) {
           const currentFontName =
             typeof node.fontName === "symbol" ? null : node.fontName;
           const nextFamily =
@@ -801,7 +804,9 @@ const handleRequest = async (
 
         if (typeof params.fillHex === "string") {
           const fillOpacity =
-            typeof params.fillOpacity === "number" ? params.fillOpacity : undefined;
+            typeof params.fillOpacity === "number"
+              ? params.fillOpacity
+              : undefined;
           applyTextFill(node, params.fillHex, fillOpacity);
           applied.fillHex = params.fillHex;
           applied.fillOpacity = fillOpacity ?? 1;
@@ -814,7 +819,10 @@ const handleRequest = async (
         }
 
         resizeNodeIfSupported(node, params.width, params.height);
-        if (typeof params.width === "number" || typeof params.height === "number") {
+        if (
+          typeof params.width === "number" ||
+          typeof params.height === "number"
+        ) {
           applied.width = node.width;
           applied.height = node.height;
         }
@@ -841,7 +849,9 @@ const handleRequest = async (
         const hasUpdates = Object.keys(params).length > 0;
 
         if (!hasUpdates) {
-          throw new Error("At least one property is required for set_node_properties");
+          throw new Error(
+            "At least one property is required for set_node_properties"
+          );
         }
 
         if (typeof params.name === "string") {
@@ -856,14 +866,19 @@ const handleRequest = async (
 
         if (typeof params.x === "number" || typeof params.y === "number") {
           if (!("x" in node) || !("y" in node)) {
-            throw new Error(`Node does not support x/y positioning: ${node.id}`);
+            throw new Error(
+              `Node does not support x/y positioning: ${node.id}`
+            );
           }
           positionNode(node, params.x, params.y);
           applied.x = node.x;
           applied.y = node.y;
         }
 
-        if (typeof params.width === "number" || typeof params.height === "number") {
+        if (
+          typeof params.width === "number" ||
+          typeof params.height === "number"
+        ) {
           resizeNodeIfSupported(node, params.width, params.height);
           applied.width = node.width;
           applied.height = node.height;
@@ -966,13 +981,17 @@ const handleRequest = async (
           throw new Error(`Unsupported gradient type: ${gradientType}`);
         }
 
-        if (!Array.isArray(params.gradientStops) || params.gradientStops.length < 2) {
+        if (
+          !Array.isArray(params.gradientStops) ||
+          params.gradientStops.length < 2
+        ) {
           throw new Error("gradientStops must have at least 2 entries");
         }
         const stops = params.gradientStops as GradientStopInput[];
 
         const transform =
-          Array.isArray(params.gradientTransform) && params.gradientTransform.length === 2
+          Array.isArray(params.gradientTransform) &&
+          params.gradientTransform.length === 2
             ? (params.gradientTransform as Transform)
             : undefined;
 
@@ -982,9 +1001,12 @@ const handleRequest = async (
         const paint = buildGradientPaint(paintType, stops, transform, opacity);
 
         if (target === "fill") {
-          (node as GeometryMixin & { fills: ReadonlyArray<Paint> }).fills = [paint];
+          (node as GeometryMixin & { fills: ReadonlyArray<Paint> }).fills = [
+            paint,
+          ];
         } else {
-          (node as GeometryMixin & { strokes: ReadonlyArray<Paint> }).strokes = [paint];
+          (node as GeometryMixin & { strokes: ReadonlyArray<Paint> }).strokes =
+            [paint];
         }
 
         return {
@@ -1024,7 +1046,9 @@ const handleRequest = async (
               if (typeof raw.color !== "string") {
                 throw new Error(`effects[${i}].color must be a hex string`);
               }
-              const offset = raw.offset as { x?: unknown; y?: unknown } | undefined;
+              const offset = raw.offset as
+                | { x?: unknown; y?: unknown }
+                | undefined;
               if (
                 !offset ||
                 typeof offset.x !== "number" ||
@@ -1043,7 +1067,8 @@ const handleRequest = async (
                 offset: { x: offset.x, y: offset.y },
                 radius: raw.radius,
                 spread: typeof raw.spread === "number" ? raw.spread : 0,
-                visible: raw.visible === undefined ? true : Boolean(raw.visible),
+                visible:
+                  raw.visible === undefined ? true : Boolean(raw.visible),
                 blendMode:
                   typeof raw.blendMode === "string"
                     ? (raw.blendMode as BlendMode)
@@ -1057,14 +1082,18 @@ const handleRequest = async (
               return {
                 type,
                 radius: raw.radius,
-                visible: raw.visible === undefined ? true : Boolean(raw.visible),
+                visible:
+                  raw.visible === undefined ? true : Boolean(raw.visible),
               } as Effect;
             }
-            throw new Error(`Unsupported effect type at effects[${i}]: ${String(type)}`);
+            throw new Error(
+              `Unsupported effect type at effects[${i}]: ${String(type)}`
+            );
           }
         );
 
-        (node as BlendMixin & { effects: ReadonlyArray<Effect> }).effects = built;
+        (node as BlendMixin & { effects: ReadonlyArray<Effect> }).effects =
+          built;
 
         return {
           type: request.type,
@@ -1112,7 +1141,9 @@ const handleRequest = async (
           }
           const pattern = (params.dashPattern as unknown[]).map((n, i) => {
             if (typeof n !== "number" || n < 0) {
-              throw new Error(`dashPattern[${i}] must be a non-negative number`);
+              throw new Error(
+                `dashPattern[${i}] must be a non-negative number`
+              );
             }
             return n;
           });
@@ -1176,8 +1207,9 @@ const handleRequest = async (
           applied.itemSpacing = params.itemSpacing;
         }
         if (typeof params.counterAxisSpacing === "number") {
-          (frame as FrameNode & { counterAxisSpacing: number }).counterAxisSpacing =
-            params.counterAxisSpacing;
+          (
+            frame as FrameNode & { counterAxisSpacing: number }
+          ).counterAxisSpacing = params.counterAxisSpacing;
           applied.counterAxisSpacing = params.counterAxisSpacing;
         }
 
@@ -1288,7 +1320,9 @@ const handleRequest = async (
 
         if (typeof params.fillHex === "string") {
           const fillOpacity =
-            typeof params.fillOpacity === "number" ? params.fillOpacity : undefined;
+            typeof params.fillOpacity === "number"
+              ? params.fillOpacity
+              : undefined;
           setSolidFill(frame, params.fillHex, fillOpacity);
         }
 
@@ -1330,7 +1364,9 @@ const handleRequest = async (
         }
         if (typeof params.fillHex === "string") {
           const fillOpacity =
-            typeof params.fillOpacity === "number" ? params.fillOpacity : undefined;
+            typeof params.fillOpacity === "number"
+              ? params.fillOpacity
+              : undefined;
           applyTextFill(text, params.fillHex, fillOpacity);
         }
 
@@ -1395,12 +1431,16 @@ const handleRequest = async (
         }
 
         if (shapeType === "LINE" && typeof params.fillHex === "string") {
-          throw new Error("LINE shapes do not support fillHex — use strokeHex instead");
+          throw new Error(
+            "LINE shapes do not support fillHex — use strokeHex instead"
+          );
         }
 
         if (typeof params.fillHex === "string") {
           const fillOpacity =
-            typeof params.fillOpacity === "number" ? params.fillOpacity : undefined;
+            typeof params.fillOpacity === "number"
+              ? params.fillOpacity
+              : undefined;
           setSolidFill(node, params.fillHex, fillOpacity);
         }
 
@@ -1415,14 +1455,13 @@ const handleRequest = async (
             throw new Error(`Node does not support strokes: ${node.id}`);
           }
           const strokeOpacity =
-            typeof params.strokeOpacity === "number" ? params.strokeOpacity : undefined;
+            typeof params.strokeOpacity === "number"
+              ? params.strokeOpacity
+              : undefined;
           setSolidFill(node, params.strokeHex, strokeOpacity, "stroke");
         }
 
-        if (
-          "strokeWeight" in node &&
-          typeof params.strokeWeight === "number"
-        ) {
+        if ("strokeWeight" in node && typeof params.strokeWeight === "number") {
           node.strokeWeight = params.strokeWeight;
         }
 
@@ -1450,11 +1489,16 @@ const handleRequest = async (
       }
       case "create_image": {
         const params = request.params ?? {};
-        if (typeof params.imageBase64 !== "string" || params.imageBase64.length === 0) {
+        if (
+          typeof params.imageBase64 !== "string" ||
+          params.imageBase64.length === 0
+        ) {
           throw new Error("imageBase64 is required for create_image");
         }
 
-        const image = figma.createImage(decodeBase64ToBytes(params.imageBase64));
+        const image = figma.createImage(
+          decodeBase64ToBytes(params.imageBase64)
+        );
         const imageSize = await image.getSizeAsync();
         const node = figma.createRectangle();
 
@@ -1680,7 +1724,9 @@ const handleRequest = async (
           throw new Error("nodeIds is required for delete_nodes");
         }
 
-        const nodes = await Promise.all(request.nodeIds.map((nodeId) => getSceneNodeById(nodeId)));
+        const nodes = await Promise.all(
+          request.nodeIds.map((nodeId) => getSceneNodeById(nodeId))
+        );
         const deletions = nodes.map((node) => ({
           nodeId: node.id,
           nodeName: node.name,
@@ -1703,7 +1749,9 @@ const handleRequest = async (
       case "get_motion_styles": {
         const motion = figma.motion;
         if (!motion || typeof motion.figmaAnimationStyles !== "function") {
-          throw new Error("figma.motion.figmaAnimationStyles is not available in this Figma version");
+          throw new Error(
+            "figma.motion.figmaAnimationStyles is not available in this Figma version"
+          );
         }
         return {
           type: request.type,
@@ -1733,14 +1781,20 @@ const handleRequest = async (
       }
       case "apply_animation_style": {
         const nodeId = request.nodeIds && request.nodeIds[0];
-        if (!nodeId) throw new Error("nodeIds is required for apply_animation_style");
+        if (!nodeId)
+          throw new Error("nodeIds is required for apply_animation_style");
         const styleId = request.params?.styleId;
-        if (typeof styleId !== "string") throw new Error("styleId is required for apply_animation_style");
+        if (typeof styleId !== "string")
+          throw new Error("styleId is required for apply_animation_style");
         const node = await getSceneNodeById(nodeId);
         if (!isMotionNode(node)) {
-          throw new Error(`Node does not support applyAnimationStyle: ${nodeId}`);
+          throw new Error(
+            `Node does not support applyAnimationStyle: ${nodeId}`
+          );
         }
-        const animationStyleData = request.params?.animationStyleData as AnimationStyleConfiguration | undefined;
+        const animationStyleData = request.params?.animationStyleData as
+          | AnimationStyleConfiguration
+          | undefined;
         node.applyAnimationStyle(styleId, animationStyleData);
         return {
           type: request.type,
@@ -1753,10 +1807,13 @@ const handleRequest = async (
       }
       case "remove_animation_style": {
         const nodeId = request.nodeIds && request.nodeIds[0];
-        if (!nodeId) throw new Error("nodeIds is required for remove_animation_style");
+        if (!nodeId)
+          throw new Error("nodeIds is required for remove_animation_style");
         const node = await getSceneNodeById(nodeId);
         if (!isMotionNode(node)) {
-          throw new Error(`Node does not support removeAnimationStyle: ${nodeId}`);
+          throw new Error(
+            `Node does not support removeAnimationStyle: ${nodeId}`
+          );
         }
         const animationStyleId = request.params?.animationStyleId;
         if (typeof animationStyleId === "string") {
@@ -1779,20 +1836,31 @@ const handleRequest = async (
 
       case "apply_manual_keyframe_track": {
         const nodeId = request.nodeIds && request.nodeIds[0];
-        if (!nodeId) throw new Error("nodeIds is required for apply_manual_keyframe_track");
+        if (!nodeId)
+          throw new Error(
+            "nodeIds is required for apply_manual_keyframe_track"
+          );
         const field = request.params?.field;
         const track = request.params?.track;
-        if (!field || !track) throw new Error("field and track are required for apply_manual_keyframe_track");
-        
+        if (!field || !track)
+          throw new Error(
+            "field and track are required for apply_manual_keyframe_track"
+          );
+
         const node = await getSceneNodeById(nodeId);
         if (!isMotionNode(node)) {
-          throw new Error(`Node does not support applyManualKeyframeTrack: ${nodeId}`);
+          throw new Error(
+            `Node does not support applyManualKeyframeTrack: ${nodeId}`
+          );
         }
-        node.applyManualKeyframeTrack(field as KeyframeField, track as ManualKeyframeTrackInput);
+        node.applyManualKeyframeTrack(
+          field as KeyframeField,
+          track as ManualKeyframeTrackInput
+        );
         return {
           type: request.type,
           requestId: request.requestId,
-          data: { 
+          data: {
             nodeId: node.id,
             manualKeyframeTracks: node.manualKeyframeTracks,
           },
@@ -1801,19 +1869,25 @@ const handleRequest = async (
 
       case "remove_manual_keyframe_track": {
         const nodeId = request.nodeIds && request.nodeIds[0];
-        if (!nodeId) throw new Error("nodeIds is required for remove_manual_keyframe_track");
+        if (!nodeId)
+          throw new Error(
+            "nodeIds is required for remove_manual_keyframe_track"
+          );
         const field = request.params?.field;
-        if (!field) throw new Error("field is required for remove_manual_keyframe_track");
-        
+        if (!field)
+          throw new Error("field is required for remove_manual_keyframe_track");
+
         const node = await getSceneNodeById(nodeId);
         if (!isMotionNode(node)) {
-          throw new Error(`Node does not support removeManualKeyframeTrack: ${nodeId}`);
+          throw new Error(
+            `Node does not support removeManualKeyframeTrack: ${nodeId}`
+          );
         }
         node.removeManualKeyframeTrack(field as KeyframeField);
         return {
           type: request.type,
           requestId: request.requestId,
-          data: { 
+          data: {
             nodeId: node.id,
             manualKeyframeTracks: node.manualKeyframeTracks,
           },
@@ -1822,22 +1896,27 @@ const handleRequest = async (
 
       case "set_timeline_duration": {
         const nodeId = request.nodeIds && request.nodeIds[0];
-        if (!nodeId) throw new Error("nodeIds is required for set_timeline_duration");
+        if (!nodeId)
+          throw new Error("nodeIds is required for set_timeline_duration");
         const timelineId = request.params?.timelineId;
         const duration = request.params?.duration;
         if (typeof timelineId !== "string" || typeof duration !== "number") {
-          throw new Error("timelineId and duration are required for set_timeline_duration");
+          throw new Error(
+            "timelineId and duration are required for set_timeline_duration"
+          );
         }
-        
+
         const node = await getSceneNodeById(nodeId);
         if (!isMotionNode(node)) {
-          throw new Error(`Node does not support setTimelineDuration: ${nodeId}`);
+          throw new Error(
+            `Node does not support setTimelineDuration: ${nodeId}`
+          );
         }
         node.setTimelineDuration(timelineId, duration);
         return {
           type: request.type,
           requestId: request.requestId,
-          data: { 
+          data: {
             nodeId: node.id,
             timelines: node.timelines,
           },

--- a/server/src/schema.ts
+++ b/server/src/schema.ts
@@ -403,7 +403,7 @@ export const setAutoLayoutInput = z.object({
 export const createPageInput = z.object({
   name: z
     .string()
-    .min(1)
+    .trim().min(1)
     .optional()
     .describe("Optional page name (defaults to Figma's 'Page N')"),
   setAsCurrent: z

--- a/server/src/schema.ts
+++ b/server/src/schema.ts
@@ -400,6 +400,21 @@ export const setAutoLayoutInput = z.object({
   fileKey: fileKeyField,
 });
 
+export const createPageInput = z.object({
+  name: z
+    .string()
+    .min(1)
+    .optional()
+    .describe("Optional page name (defaults to Figma's 'Page N')"),
+  setAsCurrent: z
+    .boolean()
+    .optional()
+    .describe(
+      "When true, switch the editor to the new page after creating it (default false)"
+    ),
+  fileKey: fileKeyField,
+});
+
 export const createFrameInput = z.object({
   name: z.string().optional().describe("Optional frame name"),
   parentId: createFigmaNodeIdSchema()
@@ -763,6 +778,8 @@ export const toolInputSchemas = {
     "At least one property must be provided"
   ),
 
+  create_page: createPageInput,
+
   create_frame: createFrameInput.refine(
     (value) => value.fillOpacity === undefined || value.fillHex !== undefined,
     "fillHex is required when fillOpacity is provided"
@@ -934,6 +951,7 @@ const rpcToArgs: Record<
     nodeId: nodeIds?.[0],
   }),
   set_auto_layout: (nodeIds, params) => ({ ...params, nodeId: nodeIds?.[0] }),
+  create_page: (_nodeIds, params) => ({ ...params }),
   create_frame: (_nodeIds, params) => ({ ...params }),
   create_text: (_nodeIds, params) => ({ ...params }),
   create_shape: (_nodeIds, params) => ({ ...params }),

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -8,6 +8,7 @@ import type { Node } from "./node.js";
 import {
   createFrameInput,
   createImageInput,
+  createPageInput,
   createShapeShape,
   createTextShape,
   createShapeInput,
@@ -346,6 +347,20 @@ export function registerTools(
       const { nodeId, fileKey, ...params } = parsed.data;
       return renderResponse(() =>
         node.sendWithParams("set_auto_layout", [nodeId], params, fileKey)
+      );
+    }
+  );
+
+  server.tool(
+    "create_page",
+    "Create a new page in the Figma document, optionally naming it and switching the editor to it. Returns the new page's ID, which can be passed as parentId to create_frame / create_text / create_shape / create_image to author content on that page. When multiple files are connected, specify fileKey.",
+    createPageInput.shape,
+    async (args): Promise<ToolResult> => {
+      const parsed = parseToolInput(toolInputSchemas.create_page, args);
+      if (!parsed.success) return parsed.error;
+      const { fileKey, ...params } = parsed.data;
+      return renderResponse(() =>
+        node.sendWithParams("create_page", undefined, params, fileKey)
       );
     }
   );


### PR DESCRIPTION
Closes #27

### Problem

The bridge exposes a fairly complete authoring surface — frames, text, shapes, images, groups, auto-layout, effects — but there is no way to create a page. As reported in #27, agents working in a file have to place everything on the current page, and the common workaround is pushing new frames far off-canvas so they don't collide with existing work.

### Solution

Adds a `create_page` tool following the same pattern as the other `create_*` tools:

- **`server/src/schema.ts`** — `createPageInput` (`name?`, `setAsCurrent?`, `fileKey?`), plus entries in `toolInputSchemas` and `rpcToArgs`, so the request goes through the same `validateRpc` path as every other tool.
- **`server/src/tools.ts`** — registers the tool with `parseToolInput` / `renderResponse`, mirroring `create_frame`.
- **`plugin/src/main/code.ts`** — adds `create_page` to the `RequestType` union and to `EDIT_REQUEST_TYPES`, and implements the handler.
- **`README.md`** — one row in the tools table and a note under *Editing Notes*.

The tool returns the new page's ID, so it composes with the existing tools without needing to switch the editor:

```
create_page { name: "Wireframes" }     → { pageId: "12:0", pageName: "Wireframes", index: 3, isCurrentPage: false }
create_frame { parentId: "12:0", ... } → frame is created on the new page
```

`getParentNodeById` already accepts any node with `appendChild`, so `PageNode` works as a `parentId` with no changes on that path.

### Notes

- **`setCurrentPageAsync`** — the manifest sets `documentAccess: "dynamic-page"`, where assigning `figma.currentPage` directly throws. The optional `setAsCurrent` flag uses the async setter instead. It defaults to `false` so creating a page is non-disruptive.
- **Dev Mode** — `create_page` is added to `EDIT_REQUEST_TYPES` so it returns the existing "requires the design editor" message instead of an opaque runtime error.
- **`name` is `.min(1)`** — an empty string would produce an unnamed page, so it's rejected at the schema level.

### Verification

- `tsc --noEmit` on `server/` — clean.
- `tsc --noEmit` on `plugin/` — same pre-existing errors as `main`, no new ones.
- `vite build` — plugin bundle builds with `create_page` present in `dist/code.js`.
- Booted the built server over stdio with an MCP client: 38 tools registered, `create_page` among them with the expected input schema.
- Schema validation exercised directly: valid inputs pass, `{name:""}` and `{setAsCurrent:"yes"}` are rejected with readable messages.

Haven't been able to exercise the handler inside a live Figma file yet — happy to test further if useful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a tool for creating pages with an optional name.
  * Pages can optionally be selected as the current page after creation.
  * Creation results include the new page’s ID, name, position, and current-page status.
  * The returned page ID can be used as a parent when creating nodes without switching pages.

* **Documentation**
  * Added guidance for using the new page creation tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->