### PR TITLE
fix(rpc): validate create_image against its wire shape

### DIFF
--- a/server/src/follower.ts
+++ b/server/src/follower.ts
@@ -33,7 +33,12 @@ export class Follower {
     });
 
     if (!response.ok) {
-      throw new Error(`Leader returned status ${response.status}`);
+      // The leader answers validation failures with a 400 whose body names the
+      // offending field — surface it instead of a bare status code (#35).
+      const body = (await response.json().catch(() => null)) as RPCResponse | null;
+      throw new Error(
+        body?.error ?? `Leader returned status ${response.status}`
+      );
     }
 
     const rpcResp = (await response.json()) as RPCResponse;

--- a/server/src/schema.ts
+++ b/server/src/schema.ts
@@ -900,6 +900,37 @@ export const toolInputSchemas = {
 type ToolName = keyof typeof toolInputSchemas;
 
 /**
+ * Wire-format schema for create_image on the follower→leader RPC path.
+ *
+ * The create_image tool handler resolves `source` (file path / URL / data URI)
+ * into `imageBase64` before forwarding, so the payload on the wire carries
+ * `imageBase64` and never `source`. `fileKey` is omitted too — it travels
+ * beside the params as a separate `sendWithParams` argument. Validating this
+ * path against the advertised `createImageInput` (which requires `source`)
+ * rejected every follower create_image call with a 400 (#35).
+ */
+const createImageRpcInput = createImageInput
+  .omit({ source: true, fileKey: true })
+  .extend({
+    imageBase64: z
+      .string()
+      .min(1)
+      .describe(
+        "Base64-encoded image bytes, resolved from `source` by the tool handler"
+      ),
+  });
+
+/**
+ * Schemas the RPC path validates against. Tools whose handlers rewrite the
+ * payload before forwarding validate their wire shape here; every other tool
+ * validates against its advertised MCP input schema.
+ */
+const rpcInputSchemas = {
+  ...toolInputSchemas,
+  create_image: createImageRpcInput,
+} as const;
+
+/**
  * Maps the RPC wire format { tool, nodeIds?, params? } to each tool's
  * expected input shape. Typed as Record<ToolName, ...> so adding a schema
  * without a mapper is a compile error.
@@ -986,10 +1017,10 @@ export function validateRpc(
   nodeIds?: string[],
   params?: Record<string, unknown>
 ): RpcValidation {
-  if (!(tool in toolInputSchemas)) return { error: null };
+  if (!(tool in rpcInputSchemas)) return { error: null };
 
   const name = tool as ToolName;
-  const result = toolInputSchemas[name].safeParse(
+  const result = rpcInputSchemas[name].safeParse(
     rpcToArgs[name](nodeIds, params)
   );
   if (!result.success) {


### PR DESCRIPTION
## Problem

`create_image` fails with `Leader returned status 400` on every follower session (#35).

The tool handler resolves `source` (file path / URL / data URI) into `imageBase64` and forwards the resolved payload:

```ts
const imageBase64 = await loadImageSourceAsBase64(source, process.cwd());
node.sendWithParams("create_image", undefined, { ...params, imageBase64 }, fileKey);
```

`source` is destructured out, so the wire payload carries `imageBase64` and no `source` — but `validateRpc` checked it against the advertised `createImageInput`, which requires `source`. The request was rejected before it ever reached the plugin. Leader-only setups never hit the RPC path, which is why this hid in single-session use.

## Fix

Following the direction from the #39 review discussion (and the approach #36/#40 converged on):

- **Separate `rpcInputSchemas` map** — `validateRpc` now checks it instead of `toolInputSchemas`. Only `create_image` is overridden; the MCP-facing input schema is untouched and still requires `source`.
- **Wire schema derived from the advertised shape** — `createImageInput.omit({ source, fileKey }).extend({ imageBase64 })`, no second hand-written `z.object` to drift. `imageBase64` is required outright (the handler always resolves before forwarding, so no "one of the two" refine is needed), and `fileKey` is omitted because it travels beside the params as a separate `sendWithParams` argument.
- **Follower surfaces the leader's validation message** — a 400 now throws the body's `error` (e.g. `Required` pointing at the offending field) instead of the bare `Leader returned status 400` that made #35 hard to diagnose.

## Testing

`tsc --noEmit` clean.

Schema-level checks against the built output:

```
PASS  RPC wire payload { imageBase64, parentId, width } accepted
PASS  RPC full payload keeps every create_image param
PASS  RPC missing imageBase64 rejected
PASS  RPC empty imageBase64 rejected
PASS  RPC malformed parentId still rejected
PASS  RPC negative width still rejected
PASS  MCP-facing create_image still requires source
PASS  create_shape unaffected
PASS  set_solid_fill alias normalisation (#39) unaffected
PASS  unknown tool passes through unvalidated
```

End-to-end against a live Figma file with this build as the leader and a follower session issuing the call: `create_image` lands in Figma (previously 400), and an invalid payload over `/rpc` returns `{"error":"Required"}` with HTTP 400, which the follower now relays verbatim.

Fixes #35. Supersedes the closed #40; same shape as the direction discussed in #36 and the #39 review thread.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image creation requests now support required Base64-encoded image data for improved compatibility with the RPC interface.

* **Bug Fixes**
  * Failed remote requests now display the error message returned by the service when available, with a clear fallback to the HTTP status message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->