### PR TITLE
fix: shut down on stdin EOF and SIGHUP to prevent zombie processes

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -10,32 +10,42 @@ import { VERSION } from "./version.js";
 const PORT = 1994;
 
 async function main(): Promise<void> {
-
-  process.on("unhandledRejection", (reason) => {
-    console.error("Unhandled rejection:", reason);
-  });
-
   const node = new Node(PORT);
   const election = new Election(PORT, node);
   await election.start();
 
-  // Graceful shutdown
-  const shutdown = () => {
-    console.error("Shutting down...");
+  let shuttingDown = false;
+  const shutdown = async (reason: string): Promise<void> => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    console.error(`Shutting down (${reason})...`);
+
+    const force = setTimeout(() => {
+      console.error("Shutdown timeout exceeded, forcing exit");
+      process.exit(0);
+    }, 5000);
+    force.unref();
+
     election.stop();
     node.stop();
     process.exit(0);
   };
 
-  process.on("SIGINT", shutdown);
-  process.on("SIGTERM", shutdown);
+  process.stdin.on("end", () => void shutdown("stdin end"));
+  process.stdin.on("close", () => void shutdown("stdin close"));
 
-  process.on("uncaughtException", (err) => {
+  process.on("SIGINT", () => void shutdown("SIGINT"));
+  process.on("SIGTERM", () => void shutdown("SIGTERM"));
+  process.on("SIGHUP", () => void shutdown("SIGHUP"));
+
+  process.on("uncaughtException", async (err) => {
     console.error("Uncaught exception:", err);
-    shutdown();
+    await shutdown("uncaughtException");
+  });
+  process.on("unhandledRejection", (reason) => {
+    console.error("Unhandled rejection:", reason);
   });
 
-  // Create MCP server (stdio transport)
   const server = new McpServer({
     name: "figma-bridge",
     version: VERSION,

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -14,21 +14,29 @@ async function main(): Promise<void> {
   const election = new Election(PORT, node);
   await election.start();
 
+  let transport: StdioServerTransport | null = null;
   let shuttingDown = false;
-  const shutdown = async (reason: string): Promise<void> => {
+  const shutdown = async (reason: string, code: number = 0): Promise<void> => {
     if (shuttingDown) return;
     shuttingDown = true;
     console.error(`Shutting down (${reason})...`);
 
     const force = setTimeout(() => {
       console.error("Shutdown timeout exceeded, forcing exit");
-      process.exit(0);
+      process.exit(code);
     }, 5000);
     force.unref();
 
     election.stop();
     node.stop();
-    process.exit(0);
+    if (transport) {
+      try {
+        await transport.close();
+      } catch (err) {
+        console.error("Transport close error:", err);
+      }
+    }
+    process.exit(code);
   };
 
   process.stdin.on("end", () => void shutdown("stdin end"));
@@ -40,7 +48,7 @@ async function main(): Promise<void> {
 
   process.on("uncaughtException", async (err) => {
     console.error("Uncaught exception:", err);
-    await shutdown("uncaughtException");
+    await shutdown("uncaughtException", 1);
   });
   process.on("unhandledRejection", (reason) => {
     console.error("Unhandled rejection:", reason);
@@ -55,7 +63,7 @@ async function main(): Promise<void> {
 
   console.error(`Starting MCP server (role: ${node.roleName})`);
 
-  const transport = new StdioServerTransport();
+  transport = new StdioServerTransport();
   await server.connect(transport);
 }
 


### PR DESCRIPTION
## Problem

`figma-mcp-bridge` accumulates zombie processes. When the MCP client (opencode, Claude Desktop, Cursor, etc.) disconnects without delivering SIGTERM — common on terminal close, IDE crash, or `kill -9` — the server never notices and keeps running indefinitely. The election `setInterval` keeps the Node event loop alive, so the process survives until manually killed or the machine reboots.

Real-world observation: two orphaned `figma-mcp-bridge` processes found consuming memory after separate opencode sessions ended normally.

## Root Cause

`StdioServerTransport` in `@modelcontextprotocol/sdk` only registers listeners for stdin `data` and `error` — not `close` or `end` (upstream issue [modelcontextprotocol/typescript-sdk#2002](https://github.com/modelcontextprotocol/typescript-sdk/issues/2002), labeled P1, fix proposed, still open).

Combined with the always-on election `setInterval` (`server/src/election.ts:28`, 3–5s), the event loop never drains, so even though the stdin pipe closes when the client dies, the server never exits.

SIGTERM-only handling is insufficient:
- **Windows**: SIGTERM is not delivered to child processes when the parent exits.
- **All platforms**: when a stdio MCP client closes its connection (not the whole process), no signal is sent — only the pipe closes. The stdin `close`/`end` event is the only reliable cross-platform shutdown signal.

## Solution

Add shutdown handlers in `server/src/index.ts` (Pattern A, matching `chrome-devtools-mcp` and `openreplay`):

| Handler | Purpose |
|---|---|
| `process.stdin.on("end" \| "close", shutdown)` | MCP stdio shutdown convention; fires when client closes the pipe |
| `process.on("SIGHUP", shutdown)` | Terminal/parent hangup |
| `process.on("SIGINT" \| "SIGTERM", shutdown)` | Preserve existing explicit-kill behavior |
| `process.on("uncaughtException", shutdown)` | Defensive — log + graceful exit |
| `process.on("unhandledRejection", log)` | Log only; a stray rejection should not kill the server |

Shutdown is async-idempotent with a 5s force-exit backstop (unref'd) in case bridge/HTTP cleanup stalls.

## What this does NOT do (deliberately)

**No idle timeout.** A top-level MCP server that self-kills on idle leaves its client with a dead pipe and no respawn path. For example, opencode's MCP client (`packages/opencode/src/mcp/index.ts`) marks the server `failed` on pipe close and never respawns — tools silently vanish until a full client restart. stdin EOF already covers every real exit scenario, so idle reaping only hurts UX.

(Idle reaping only makes sense for "bridge child" architectures where a long-lived parent spawns short-lived per-context children — see `mksglu/context-mode`'s `lifecycle.ts`, which gates the idle reaper on `CONTEXT_MODE_BRIDGE_DEPTH>0` and explicitly disables it for top-level servers.)

## Testing

No test framework configured (`server/package.json` has only `build` and `prepublishOnly` scripts). Manual integration tests:

**Test A — SIGINT (graceful regression):**
```
spawn node dist/index.js → wait 2s → kill -INT $PID
```
✓ "Shutting down (SIGINT)..." printed, process exited cleanly.

**Test B — stdin EOF (core fix):**
```
node dist/index.js < /dev/null
```
✓ "Shutting down (stdin end)..." printed immediately, process exited.

**Test C — parent SIGKILL (real-world scenario):**
```
parent spawns child → kill -KILL $PARENT_PID → wait → pgrep figma-mcp-bridge
```
✓ Child detected stdin EOF, printed "Shutting down (stdin end)...", exited. `pgrep` confirmed no surviving processes.

(TypeScript build also clean: `npm run build` succeeds with no errors.)

## References

- Upstream SDK bug: https://github.com/modelcontextprotocol/typescript-sdk/issues/2002
- Same pattern in `chrome-devtools-mcp`: https://github.com/ChromeDevTools/chrome-devtools-mcp/blob/main/src/bin/chrome-devtools-mcp-main.ts
- Same pattern in `openreplay`: https://github.com/openreplay/openreplay/blob/main/mcp_app/server.ts

## Checklist

- [x] Code follows existing style (no comments added per repo convention)
- [x] `npm run build` passes
- [x] Manual tests A/B/C pass
- [x] Commit message follows Conventional Commits
- [x] No breaking changes — only adds new handlers, preserves SIGINT/SIGTERM behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved application shutdown behavior for cleaner and more reliable exits.
  - Added handling for common stop and termination events.
  - Ensured shutdown cleanup runs only once, avoiding duplicate or conflicting exit attempts.
  - Prevented shutdown processes from hanging indefinitely by enforcing a fallback exit.
  - Improved resilience when unexpected errors occur during runtime.
  - Added clearer shutdown reason reporting to support troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->