### PR TITLE
Make Figma bridge port configurable

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "concurrently \"vite build --watch\" \"vite build --watch -c vite.config.main.ts\"",
-    "build": "vite build && vite build -c vite.config.main.ts"
+    "build": "vite build && vite build -c vite.config.main.ts",
+    "build:instance": "node scripts/build-instance.mjs"
   },
   "dependencies": {
     "react": "^18.3.1",

--- a/plugin/scripts/build-instance.mjs
+++ b/plugin/scripts/build-instance.mjs
@@ -1,0 +1,61 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const [instance, rawPort, pluginName] = process.argv.slice(2);
+
+if (!instance || !/^[a-z0-9-]+$/.test(instance)) {
+  throw new Error("instance must use lowercase letters, numbers, and hyphens");
+}
+
+if (!rawPort || !/^\d+$/.test(rawPort)) {
+  throw new Error("port must be an integer");
+}
+
+const port = Number(rawPort);
+if (port < 1 || port > 65535) {
+  throw new Error("port must be between 1 and 65535");
+}
+
+const outputDirectory = `dist/${instance}`;
+const environment = {
+  ...process.env,
+  FIGMA_BRIDGE_PORT: String(port),
+  FIGMA_PLUGIN_OUT_DIR: outputDirectory
+};
+const vite = resolve("node_modules/vite/bin/vite.js");
+
+for (const arguments_ of [["build"], ["build", "-c", "vite.config.main.ts"]]) {
+  const result = spawnSync(process.execPath, [vite, ...arguments_], {
+    cwd: resolve("."),
+    env: environment,
+    stdio: "inherit"
+  });
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+const manifest = {
+  name: pluginName || `Figma MCP Bridge ${instance}`,
+  id: `figma-mcp-bridge-${instance}`,
+  api: "1.0.0",
+  main: "code.js",
+  ui: "index.html",
+  permissions: [],
+  networkAccess: {
+    allowedDomains: [`ws://localhost:${port}`],
+    reasoning: "Connects to the local MCP server through WebSocket"
+  },
+  documentAccess: "dynamic-page",
+  editorType: ["figma", "dev"],
+  capabilities: ["inspect"]
+};
+
+await mkdir(resolve(outputDirectory), { recursive: true });
+await writeFile(
+  resolve(outputDirectory, "manifest.json"),
+  `${JSON.stringify(manifest, null, 2)}\n`
+);
+
+console.log(`Built ${manifest.name} for port ${port}: ${outputDirectory}/manifest.json`);

--- a/plugin/src/ui/App.tsx
+++ b/plugin/src/ui/App.tsx
@@ -51,7 +51,7 @@ type PluginStatus = {
   selectionCount: number;
 };
 
-const WS_BASE_URL = "ws://localhost:1994/ws";
+const WS_BASE_URL = `ws://localhost:${__FIGMA_BRIDGE_PORT__}/ws`;
 
 export default function App() {
   const [connected, setConnected] = useState(false);

--- a/plugin/src/ui/env.d.ts
+++ b/plugin/src/ui/env.d.ts
@@ -1,0 +1,1 @@
+declare const __FIGMA_BRIDGE_PORT__: number;

--- a/plugin/vite.config.main.ts
+++ b/plugin/vite.config.main.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from "vite";
 
+const outputDirectory = process.env.FIGMA_PLUGIN_OUT_DIR ?? "dist";
+
 export default defineConfig({
   build: {
     target: "es2015",
@@ -9,7 +11,7 @@ export default defineConfig({
       name: "code",
       fileName: () => "code.js"
     },
-    outDir: "dist",
+    outDir: outputDirectory,
     emptyOutDir: false,
     minify: false
   }

--- a/plugin/vite.config.ts
+++ b/plugin/vite.config.ts
@@ -2,13 +2,23 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { viteSingleFile } from "vite-plugin-singlefile";
 
+const bridgePort = Number(process.env.FIGMA_BRIDGE_PORT ?? "1994");
+if (!Number.isInteger(bridgePort) || bridgePort < 1 || bridgePort > 65535) {
+  throw new Error("FIGMA_BRIDGE_PORT must be an integer between 1 and 65535");
+}
+
+const outputDirectory = process.env.FIGMA_PLUGIN_OUT_DIR ?? "dist";
+
 export default defineConfig({
   plugins: [react(), viteSingleFile()],
   root: "./src/ui",
+  define: {
+    __FIGMA_BRIDGE_PORT__: JSON.stringify(bridgePort)
+  },
   build: {
     target: "es2015",
     cssCodeSplit: false,
-    outDir: "../../dist",
+    outDir: `../../${outputDirectory}`,
     rollupOptions: {
       output: {
         inlineDynamicImports: true

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -4,10 +4,11 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { Node } from "./node.js";
 import { Election } from "./election.js";
+import { bridgePortFromEnvironment } from "./port.js";
 import { registerTools } from "./tools.js";
 import { VERSION } from "./version.js";
 
-const PORT = 1994;
+const PORT = bridgePortFromEnvironment();
 
 async function main(): Promise<void> {
 

--- a/server/src/port.ts
+++ b/server/src/port.ts
@@ -1,0 +1,20 @@
+const DEFAULT_BRIDGE_PORT = 1994;
+
+export const bridgePortFromEnvironment = (
+  value = process.env.FIGMA_BRIDGE_PORT
+): number => {
+  if (value === undefined || value === "") {
+    return DEFAULT_BRIDGE_PORT;
+  }
+
+  if (!/^\d+$/.test(value)) {
+    throw new Error(`FIGMA_BRIDGE_PORT must be an integer: ${value}`);
+  }
+
+  const port = Number(value);
+  if (port < 1 || port > 65535) {
+    throw new Error(`FIGMA_BRIDGE_PORT must be between 1 and 65535: ${value}`);
+  }
+
+  return port;
+};


### PR DESCRIPTION
## Summary
- read the bridge listen port from `FIGMA_BRIDGE_PORT`
- build plugin instances with a matching WebSocket port and manifest
- keep the current `1994` behavior as the default

## Verification
- `bun run build` in `server`
- built plugin instances for ports 1994 and 1995
- verified each generated manifest and UI use its assigned port

No issue is associated with this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the bridge port through an environment setting.
  * Added a dedicated instance build process that generates instance-specific plugin output and manifests.
  * Added configurable build output directories.

* **Bug Fixes**
  * Added validation for bridge port values, including integer format and the valid range of 1–65,535.
  * Preserved port 1994 as the default when no custom port is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->