### PR TITLE
feat: import_html_layers — bulk-import an html-figma layer tree as editable nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ If you want to know more about how it works, read the [How it works](#how-it-wor
 | `create_text`                  | Create a new text node                                                                 |
 | `create_shape`                 | Create a rectangle, ellipse, or line                                                   |
 | `create_image`                 | Create an image-backed rectangle from a local path, URL, or data URI                   |
+| `import_html_layers`           | Bulk-import an html-figma layer tree (JSON) as frames, text, rectangles, and vectors   |
 | `duplicate_nodes`              | Duplicate nodes in place                                                               |
 | `reparent_nodes`               | Move nodes into another parent                                                         |
 | `group_nodes`                  | Wrap a list of nodes (sharing a parent) in a new group                                 |
@@ -113,6 +114,7 @@ All tools accept an optional `fileKey` parameter when multiple Figma files are c
 - Text edits automatically load the fonts currently used by the target text node before applying the new content.
 - New text nodes default to `Inter Regular` unless a font is provided.
 - `create_image` reads local paths relative to the MCP server working directory unless you pass an absolute path.
+- `import_html_layers` takes a JSON file produced by [html-figma](https://github.com/sergcen/html-to-figma)'s browser `htmlToFigma()`. The path resolves relative to the MCP server working directory and must stay inside it, even when absolute. Everything lands inside one wrapper frame, and the response reports `layerCount` against `expectedLayerCount` so partial imports are visible.
 - `create_page` returns the new page's ID — pass it as `parentId` to `create_frame` / `create_text` / `create_shape` / `create_image` to author content on that page without switching the editor.
 
 ### What You Can Build

--- a/plugin/src/html-figma/NOTICE.md
+++ b/plugin/src/html-figma/NOTICE.md
@@ -1,0 +1,33 @@
+# Vendored: html-figma (figma-side renderer)
+
+The files in this directory are vendored from
+[sergcen/html-to-figma](https://github.com/sergcen/html-to-figma)
+(npm package `html-figma`, version 0.3.1), licensed under the MIT License.
+
+Copyright (c) Sergei Savelev
+
+Vendored because the upstream package is unmaintained (last release ~5 years
+ago) and the plugin only needs the small figma-side renderer
+(`addLayersToFrame` and its helpers). Only `src/figma/*`, `src/utils.ts`, and
+`src/types.ts` are included; the browser-side serializer is not part of this
+plugin.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugin/src/html-figma/figma/dropOffset.ts
+++ b/plugin/src/html-figma/figma/dropOffset.ts
@@ -1,0 +1,20 @@
+interface DropOffsetParams {
+  dropPosition: { clientX: number; clientY: number };
+  windowSize: { width: number; height: number };
+  offset: { x: number; y: number };
+}
+
+export function getDropOffset(payload: DropOffsetParams) {
+  const { dropPosition, windowSize, offset } = payload;
+
+  const { bounds, zoom } = figma.viewport;
+  const hasUI = Math.abs((bounds.width * zoom) / windowSize.width) < 0.99;
+  const leftPaneWidth = windowSize.width - bounds.width * zoom - 240;
+  const xFromCanvas = hasUI ? dropPosition.clientX - leftPaneWidth : dropPosition.clientX;
+  const yFromCanvas = hasUI ? dropPosition.clientY - 40 : dropPosition.clientY;
+
+  return {
+    x: bounds.x + xFromCanvas / zoom - offset.x,
+    y: bounds.y + yFromCanvas / zoom - offset.y,
+  };
+}

--- a/plugin/src/html-figma/figma/getFont.ts
+++ b/plugin/src/html-figma/figma/getFont.ts
@@ -1,0 +1,47 @@
+const fontCache: { [key: string]: FontName | undefined } = {};
+
+const normalizeName = (str: string) => str.toLowerCase().replace(/[^a-z]/gi, "");
+
+export const defaultFont = { family: "Roboto", style: "Regular" };
+
+let cachedAvailableFonts: Font[] | null = null;
+
+const getAvailableFontNames = async () => {
+  if (cachedAvailableFonts) {
+    return cachedAvailableFonts;
+  } else {
+    return (await figma.listAvailableFontsAsync()).filter(
+      (font: Font) => font.fontName.style === "Regular"
+    );
+  }
+};
+
+// TODO: keep list of fonts not found
+export async function getMatchingFont(fontStr: string) {
+  const cached = fontCache[fontStr];
+  if (cached) {
+    return cached;
+  }
+
+  const availableFonts = await getAvailableFontNames();
+  const familySplit = fontStr.split(/\s*,\s*/);
+
+  for (const family of familySplit) {
+    const normalized = normalizeName(family);
+    for (const availableFont of availableFonts) {
+      const normalizedAvailable = normalizeName(availableFont.fontName.family);
+      if (normalizedAvailable === normalized) {
+        const cached = fontCache[normalizedAvailable];
+        if (cached) {
+          return cached;
+        }
+        await figma.loadFontAsync(availableFont.fontName);
+        fontCache[fontStr] = availableFont.fontName;
+        fontCache[normalizedAvailable] = availableFont.fontName;
+        return availableFont.fontName;
+      }
+    }
+  }
+
+  return defaultFont;
+}

--- a/plugin/src/html-figma/figma/getFont.ts
+++ b/plugin/src/html-figma/figma/getFont.ts
@@ -6,42 +6,60 @@ export const defaultFont = { family: "Roboto", style: "Regular" };
 
 let cachedAvailableFonts: Font[] | null = null;
 
-const getAvailableFontNames = async () => {
-  if (cachedAvailableFonts) {
-    return cachedAvailableFonts;
-  } else {
-    return (await figma.listAvailableFontsAsync()).filter(
-      (font: Font) => font.fontName.style === "Regular"
-    );
+const getAvailableFonts = async () => {
+  if (!cachedAvailableFonts) {
+    cachedAvailableFonts = await figma.listAvailableFontsAsync();
   }
+  return cachedAvailableFonts;
+};
+
+/**
+ * Figma addresses weights by style name, and which names a family ships varies,
+ * so each CSS numeric weight maps to an ordered list of candidates ending at
+ * Regular. Without a weight the result is Regular, matching a serialization
+ * that carries no `fontWeight`.
+ */
+const styleCandidates = (fontWeight?: number): string[] => {
+  if (typeof fontWeight !== "number" || fontWeight < 500) return ["Regular"];
+  if (fontWeight >= 900) return ["Black", "ExtraBold", "Bold", "Regular"];
+  if (fontWeight >= 800) return ["ExtraBold", "Bold", "Regular"];
+  if (fontWeight >= 700) return ["Bold", "SemiBold", "Regular"];
+  if (fontWeight >= 600) return ["SemiBold", "Bold", "Medium", "Regular"];
+  return ["Medium", "SemiBold", "Regular"];
 };
 
 // TODO: keep list of fonts not found
-export async function getMatchingFont(fontStr: string) {
-  const cached = fontCache[fontStr];
+export async function getMatchingFont(fontStr: string, fontWeight?: number): Promise<FontName> {
+  const cacheKey = `${fontStr}|${fontWeight ?? ""}`;
+  const cached = fontCache[cacheKey];
   if (cached) {
     return cached;
   }
 
-  const availableFonts = await getAvailableFontNames();
-  const familySplit = fontStr.split(/\s*,\s*/);
+  const availableFonts = await getAvailableFonts();
+  const candidates = styleCandidates(fontWeight);
 
-  for (const family of familySplit) {
+  for (const family of fontStr.split(/\s*,\s*/)) {
     const normalized = normalizeName(family);
-    for (const availableFont of availableFonts) {
-      const normalizedAvailable = normalizeName(availableFont.fontName.family);
-      if (normalizedAvailable === normalized) {
-        const cached = fontCache[normalizedAvailable];
-        if (cached) {
-          return cached;
-        }
-        await figma.loadFontAsync(availableFont.fontName);
-        fontCache[fontStr] = availableFont.fontName;
-        fontCache[normalizedAvailable] = availableFont.fontName;
-        return availableFont.fontName;
+    const familyFonts = availableFonts.filter(
+      (font: Font) => normalizeName(font.fontName.family) === normalized
+    );
+    if (!familyFonts.length) {
+      continue;
+    }
+
+    for (const style of candidates) {
+      const match = familyFonts.find((font: Font) => font.fontName.style === style);
+      if (!match) {
+        continue;
       }
+      await figma.loadFontAsync(match.fontName);
+      fontCache[cacheKey] = match.fontName;
+      return match.fontName;
     }
   }
 
+  await figma.loadFontAsync(defaultFont);
+  fontCache[cacheKey] = defaultFont;
   return defaultFont;
 }

--- a/plugin/src/html-figma/figma/helpers.ts
+++ b/plugin/src/html-figma/figma/helpers.ts
@@ -1,0 +1,153 @@
+const allPropertyNames = [
+  "id",
+  "width",
+  "height",
+  "currentPage",
+  "cancel",
+  "origin",
+  "onmessage",
+  "center",
+  "zoom",
+  "fontName",
+  "name",
+  "visible",
+  "locked",
+  "constraints",
+  "relativeTransform",
+  "x",
+  "y",
+  "rotation",
+  "constrainProportions",
+  "layoutAlign",
+  "layoutGrow",
+  "opacity",
+  "blendMode",
+  "isMask",
+  "effects",
+  "effectStyleId",
+  "expanded",
+  "backgrounds",
+  "backgroundStyleId",
+  "fills",
+  "strokes",
+  "strokeWeight",
+  "strokeMiterLimit",
+  "strokeAlign",
+  "strokeCap",
+  "strokeJoin",
+  "dashPattern",
+  "fillStyleId",
+  "strokeStyleId",
+  "cornerRadius",
+  "cornerSmoothing",
+  "topLeftRadius",
+  "topRightRadius",
+  "bottomLeftRadius",
+  "bottomRightRadius",
+  "exportSettings",
+  "overflowDirection",
+  "numberOfFixedChildren",
+  "description",
+  "layoutMode",
+  "primaryAxisSizingMode",
+  "counterAxisSizingMode",
+  "primaryAxisAlignItems",
+  "counterAxisAlignItems",
+  "paddingLeft",
+  "paddingRight",
+  "paddingTop",
+  "paddingBottom",
+  "itemSpacing",
+  "layoutGrids",
+  "gridStyleId",
+  "clipsContent",
+  "guides",
+  "guides",
+  "selection",
+  "selectedTextRange",
+  "backgrounds",
+  "arcData",
+  "pointCount",
+  "pointCount",
+  "innerRadius",
+  "vectorNetwork",
+  "vectorPaths",
+  "handleMirroring",
+  "textAlignHorizontal",
+  "textAlignVertical",
+  "textAutoResize",
+  "paragraphIndent",
+  "paragraphSpacing",
+  "autoRename",
+  "textStyleId",
+  "fontSize",
+  "fontName",
+  "textCase",
+  "textDecoration",
+  "letterSpacing",
+  "lineHeight",
+  "characters",
+  "mainComponent",
+  "scaleFactor",
+  "booleanOperation",
+  "expanded",
+  "name",
+  "type",
+  "paints",
+  "type",
+  "fontSize",
+  "textDecoration",
+  "fontName",
+  "letterSpacing",
+  "lineHeight",
+  "paragraphIndent",
+  "paragraphSpacing",
+  "textCase",
+  "type",
+  "effects",
+  "type",
+  "layoutGrids",
+];
+
+type AnyStringMap = { [key: string]: any };
+
+export function assign(a: BaseNode & AnyStringMap, b: AnyStringMap) {
+  for (const key in b) {
+    const value = b[key];
+    if (key === "data" && value && typeof value === "object") {
+      const currentData = JSON.parse(a.getSharedPluginData("builder", "data") || "{}") || {};
+      const newData = value;
+      const mergedData = Object.assign({}, currentData, newData);
+      // TODO merge plugin data
+      a.setSharedPluginData("builder", "data", JSON.stringify(mergedData));
+    } else if (
+      typeof value != "undefined" &&
+      ["width", "height", "type", "ref", "children", "svg"].indexOf(key) === -1
+    ) {
+      try {
+        a[key] = b[key];
+      } catch (err) {
+        console.warn(`Assign error for property "${key}"`, a, b, err);
+      }
+    }
+  }
+}
+
+// The Figma nodes are hard to inspect at a glance because almost all properties are non enumerable
+// getters. This removes that wrapping for easier inspecting
+export const cloneObject = (obj: any, valuesSet = new Set()) => {
+  if (!obj || typeof obj !== "object") {
+    return obj;
+  }
+
+  const newObj: any = Array.isArray(obj) ? [] : {};
+
+  for (const property of allPropertyNames) {
+    const value = obj[property];
+    if (value !== undefined && typeof value !== "symbol") {
+      newObj[property] = obj[property];
+    }
+  }
+
+  return newObj;
+};

--- a/plugin/src/html-figma/figma/images.ts
+++ b/plugin/src/html-figma/figma/images.ts
@@ -1,0 +1,16 @@
+import { getImageFills } from "../utils";
+
+export async function processImages(layer: RectangleNode | TextNode) {
+  const images = getImageFills(layer);
+  return (
+    images &&
+    Promise.all(
+      images.map(async (image: any) => {
+        if (image && image.intArr) {
+          image.imageHash = await figma.createImage(image.intArr).hash;
+          delete image.intArr;
+        }
+      })
+    )
+  );
+}

--- a/plugin/src/html-figma/figma/index.ts
+++ b/plugin/src/html-figma/figma/index.ts
@@ -1,5 +1,5 @@
 import { LayerNode, PlainLayerNode } from "../types";
-import { traverse, traverseAsync } from "../utils";
+import { traverseAsync } from "../utils";
 import { processLayer } from "./processLayer";
 
 interface LayerCbArgs {

--- a/plugin/src/html-figma/figma/index.ts
+++ b/plugin/src/html-figma/figma/index.ts
@@ -1,0 +1,30 @@
+import { LayerNode, PlainLayerNode } from "../types";
+import { traverse, traverseAsync } from "../utils";
+import { processLayer } from "./processLayer";
+
+interface LayerCbArgs {
+  node: SceneNode;
+  layer: LayerNode;
+  parent: LayerNode | null;
+}
+
+export async function addLayersToFrame(
+  layers: PlainLayerNode[],
+  baseFrame: PageNode | FrameNode,
+  onLayerProcess?: (args: LayerCbArgs) => void
+) {
+  for (const rootLayer of layers) {
+    await traverseAsync(rootLayer, async (layer, parent) => {
+      try {
+        const node = await processLayer(layer, parent, baseFrame);
+
+        onLayerProcess?.({ node, layer, parent });
+      } catch (err) {
+        console.warn("Error on layer:", layer, err);
+      }
+    });
+  }
+}
+
+export * from "./getFont";
+export * from "./dropOffset";

--- a/plugin/src/html-figma/figma/processLayer.ts
+++ b/plugin/src/html-figma/figma/processLayer.ts
@@ -70,10 +70,13 @@ export const processLayer = async (
     const text = node as TextNode;
 
     if (layer.fontFamily) {
-      text.fontName = await getMatchingFont(layer.fontFamily);
+      text.fontName = await getMatchingFont(layer.fontFamily, layer.fontWeight);
 
       delete layer.fontFamily;
     }
+    // Consumed above. TextNode.fontWeight is derived from fontName and
+    // read-only, so leaving it here would only make assign() warn.
+    delete layer.fontWeight;
 
     assign(text, layer);
     text.resize(layer.width || 1, layer.height || 1);

--- a/plugin/src/html-figma/figma/processLayer.ts
+++ b/plugin/src/html-figma/figma/processLayer.ts
@@ -1,0 +1,106 @@
+import { getImageFills } from "../utils";
+import { processImages } from "./images";
+import { getMatchingFont } from "./getFont";
+import { assign } from "./helpers";
+import { LayerNode, PlainLayerNode, WithRef } from "../types";
+
+const processDefaultElement = (layer: LayerNode, node: SceneNode): SceneNode => {
+  node.x = layer.x as number;
+  node.y = layer.y as number;
+  node.resize(layer.width || 1, layer.height || 1);
+  assign(node, layer);
+  // rects.push(frame);
+  return node;
+};
+
+const createNodeFromLayer = (layer: LayerNode) => {
+  if (layer.type === "FRAME" || layer.type === "GROUP") {
+    return figma.createFrame();
+  }
+
+  if (layer.type === "SVG" && layer.svg) {
+    return figma.createNodeFromSvg(layer.svg);
+  }
+
+  if (layer.type === "RECTANGLE") {
+    return figma.createRectangle();
+  }
+
+  if (layer.type === "TEXT") {
+    return figma.createText();
+  }
+
+  if (layer.type === "COMPONENT") {
+    return figma.createComponent();
+  }
+};
+
+const SIMPLE_TYPES = ["FRAME", "GROUP", "SVG", "RECTANGLE", "COMPONENT"];
+
+export const processLayer = async (
+  layer: PlainLayerNode,
+  parent: WithRef<LayerNode> | null,
+  baseFrame: PageNode | FrameNode
+) => {
+  const parentFrame = (parent?.ref as FrameNode) || baseFrame;
+
+  if (typeof layer.x !== "number" || typeof layer.y !== "number") {
+    throw Error("Layer coords not defined");
+  }
+
+  const node = createNodeFromLayer(layer);
+
+  if (!node) {
+    throw Error(`${layer.type} not implemented`);
+  }
+
+  if (SIMPLE_TYPES.includes(layer.type as string)) {
+    parentFrame.appendChild(processDefaultElement(layer, node));
+  }
+  // @ts-expect-error
+  layer.ref = node;
+
+  if (layer.type === "RECTANGLE") {
+    if (getImageFills(layer as RectangleNode)) {
+      await processImages(layer as RectangleNode);
+    }
+  }
+
+  if (layer.type === "TEXT") {
+    const text = node as TextNode;
+
+    if (layer.fontFamily) {
+      text.fontName = await getMatchingFont(layer.fontFamily);
+
+      delete layer.fontFamily;
+    }
+
+    assign(text, layer);
+    text.resize(layer.width || 1, layer.height || 1);
+
+    text.textAutoResize = "HEIGHT";
+
+    let adjustments = 0;
+    if (layer.lineHeight) {
+      text.lineHeight = layer.lineHeight;
+    }
+    // Adjust text width
+    while (typeof layer.height === "number" && text.height > layer.height) {
+      if (adjustments++ > 5) {
+        console.warn("Too many font adjustments", text, layer);
+
+        break;
+      }
+
+      try {
+        text.resize(text.width + 1, text.height);
+      } catch (err) {
+        console.warn("Error on resize text:", layer, text, err);
+      }
+    }
+
+    parentFrame.appendChild(text);
+  }
+
+  return node;
+};

--- a/plugin/src/html-figma/types.ts
+++ b/plugin/src/html-figma/types.ts
@@ -1,0 +1,55 @@
+export interface Unit {
+  unit: "PIXELS";
+  value: number;
+}
+
+export interface SvgNode extends DefaultShapeMixin, ConstraintMixin {
+  type: "SVG";
+  svg: string;
+}
+
+export type WithWriteChildren<T> = Partial<T> & {
+  children: WithWriteChildren<T>[];
+};
+
+export type WithRef<T> = T & {
+  ref?: SceneNode;
+};
+
+// export interface Layer {
+//     ref: Element,
+//     x: number,
+//     y: number,
+//     width: number,
+//     height: number,
+//     fills:
+//     clipsContent: !!overflowHidden,
+//     fills: fills as any,
+//     children: [],
+//     opacity: getOpacity(computedStyle),
+//     zIndex: Number(computedStyle.zIndex),
+// }
+
+export type LayerNode = Partial<
+  RectangleNode | TextNode | FrameNode | SvgNode | GroupNode | ComponentNode
+>;
+
+export type PlainLayerNode = Partial<LayerNode> & {
+  fontFamily?: string;
+};
+
+export type MetaLayerNode = WithMeta<LayerNode>;
+export type MetaTextNode = WithMeta<TextNode>;
+
+export type WithMeta<T> = Partial<Omit<T, "children">> & {
+  ref?: SceneNode | Element | HTMLElement;
+  zIndex?: number;
+  fontFamily?: string;
+  textValue?: WithMeta<TextNode>;
+  before?: WithMeta<T>;
+  after?: WithMeta<T>;
+  borders?: WithMeta<T>;
+  children?: WithMeta<T>[];
+  constraints?: FrameNode["constraints"];
+  clipsContent?: FrameNode["clipsContent"];
+};

--- a/plugin/src/html-figma/types.ts
+++ b/plugin/src/html-figma/types.ts
@@ -36,6 +36,7 @@ export type LayerNode = Partial<
 
 export type PlainLayerNode = Partial<LayerNode> & {
   fontFamily?: string;
+  fontWeight?: number;
 };
 
 export type MetaLayerNode = WithMeta<LayerNode>;

--- a/plugin/src/html-figma/utils.ts
+++ b/plugin/src/html-figma/utils.ts
@@ -1,0 +1,216 @@
+import { LayerNode, Unit } from "./types";
+
+export const hasChildren = <T>(node: T) =>
+  // @ts-expect-error
+  node && Array.isArray(node.children);
+
+export function traverse(
+  layer: LayerNode,
+  cb: (layer: LayerNode, parent: LayerNode | null) => void,
+  parent: LayerNode | null = null
+) {
+  if (layer) {
+    cb(layer, parent);
+    if (hasChildren<LayerNode>(layer)) {
+      // @ts-expect-error
+      layer.children.forEach((child) => traverse(child as LayerNode, cb, layer));
+    }
+  }
+}
+
+export function traverseMap<T>(
+  layer: T,
+  cb: (layer: T, parent: T | null) => T | undefined,
+  parent: T | null = null
+) {
+  if (layer) {
+    const newLayer = cb(layer, parent);
+    // @ts-expect-error
+    if (newLayer?.children?.length) {
+      // @ts-expect-error
+      newLayer.children = newLayer.children.map((child) => traverseMap(child, cb, layer));
+    }
+    return newLayer;
+  }
+}
+
+export async function traverseAsync<T>(
+  layer: T,
+  cb: (layer: T, parent: T | null) => void,
+  parent: T | null = null
+) {
+  if (layer) {
+    await cb(layer, parent);
+    if (hasChildren(layer)) {
+      // @ts-ignore
+      for (let child of layer.children.reverse()) {
+        await traverseAsync(child as T, cb, layer);
+      }
+    }
+  }
+}
+
+export function size(obj: object) {
+  return Object.keys(obj).length;
+}
+
+export const capitalize = (str: string) => str[0].toUpperCase() + str.substring(1);
+
+interface ParsedColor {
+  r: number;
+  g: number;
+  b: number;
+  a: number;
+}
+
+export function getRgb(colorString?: string | null): ParsedColor | null {
+  if (!colorString) {
+    return null;
+  }
+  const [_1, r, g, b, _2, a] = (colorString!.match(
+    /rgba?\(([\d\.]+), ([\d\.]+), ([\d\.]+)(, ([\d\.]+))?\)/
+  )! || []) as string[];
+
+  const none = a && parseFloat(a) === 0;
+
+  if (r && g && b && !none) {
+    return {
+      r: parseInt(r) / 255,
+      g: parseInt(g) / 255,
+      b: parseInt(b) / 255,
+      a: a ? parseFloat(a) : 1,
+    };
+  }
+  return null;
+}
+
+export const fastClone = (data: any) =>
+  typeof data === "symbol" ? null : JSON.parse(JSON.stringify(data));
+
+export const toNum = (v: string): number => {
+  // if (!/px$/.test(v) && v !== '0') return v;
+  if (!/px$/.test(v) && v !== "0") return 0;
+  const n = parseFloat(v);
+  // return !isNaN(n) ? n : v;
+  return !isNaN(n) ? n : 0;
+};
+
+export const toPercent = (v: string): number => {
+  // if (!/px$/.test(v) && v !== '0') return v;
+  if (!/%$/.test(v) && v !== "0") return 0;
+  const n = parseInt(v);
+  // return !isNaN(n) ? n : v;
+  return !isNaN(n) ? n / 100 : 0;
+};
+
+export const parseUnits = (str?: string | null, relative?: number): null | Unit => {
+  if (!str) {
+    return null;
+  }
+  let value = toNum(str);
+  if (relative && !value) {
+    const percent = toPercent(str);
+
+    if (!percent) return null;
+
+    value = relative * percent;
+  }
+  // const match = str.match(/([\d\.]+)px/);
+  // const val = match && match[1];
+  if (value) {
+    return {
+      unit: "PIXELS",
+      value,
+    };
+  }
+  return null;
+};
+
+const LENGTH_REG = /^[0-9]+[a-zA-Z%]+?$/;
+
+const isLength = (v: string) => v === "0" || LENGTH_REG.test(v);
+
+interface ParsedBoxShadow {
+  inset: boolean;
+  offsetX: number;
+  offsetY: number;
+  blurRadius: number;
+  spreadRadius: number;
+  color: ParsedColor;
+}
+
+const parseMultipleCSSValues = (str: string) => {
+  const parts = [];
+  let lastSplitIndex = 0;
+  let skobka = false;
+
+  for (let i = 0; i < str.length; i++) {
+    if (str[i] === "," && !skobka) {
+      parts.push(str.slice(lastSplitIndex, i));
+      lastSplitIndex = i + 1;
+    } else if (str[i] === "(") {
+      skobka = true;
+    } else if (str[i] === ")") {
+      skobka = false;
+    }
+  }
+  parts.push(str.slice(lastSplitIndex));
+
+  return parts.map((s) => s.trim());
+};
+
+export const parseBoxShadowValue = (str: string): ParsedBoxShadow => {
+  // TODO: this is broken for multiple box shadows
+  if (str.startsWith("rgb")) {
+    // Werid computed style thing that puts the color in the front not back
+    const colorMatch = str.match(/(rgba?\(.+?\))(.+)/);
+    if (colorMatch) {
+      str = (colorMatch[2] + " " + colorMatch[1]).trim();
+    }
+  }
+
+  const PARTS_REG = /\s(?![^(]*\))/;
+  const parts = str.split(PARTS_REG);
+  const inset = parts.includes("inset");
+  const last = parts.slice(-1)[0];
+  const color = !isLength(last) ? last : "rgba(0, 0, 0, 1)";
+
+  const nums = parts
+    .filter((n) => n !== "inset")
+    .filter((n) => n !== color)
+    .map(toNum);
+
+  const [offsetX, offsetY, blurRadius, spreadRadius] = nums;
+
+  const parsedColor = getRgb(color);
+
+  if (!parsedColor) {
+    console.error("Parse color error: " + color);
+  }
+
+  return {
+    inset,
+    offsetX,
+    offsetY,
+    blurRadius,
+    spreadRadius,
+    color: parsedColor || { r: 0, g: 0, b: 0, a: 1 },
+  };
+};
+
+export const getOpacity = (styles: CSSStyleDeclaration) => {
+  return Number(styles.opacity);
+};
+
+export const parseBoxShadowValues = (str: string): ParsedBoxShadow[] => {
+  const values = parseMultipleCSSValues(str);
+
+  return values.map((s) => parseBoxShadowValue(s));
+};
+
+export function getImageFills(layer: RectangleNode | TextNode) {
+  const images = Array.isArray(layer.fills) && layer.fills.filter((item) => item.type === "IMAGE");
+  return images;
+}
+
+export const defaultPlaceholderColor = getRgb("rgba(178, 178, 178, 1)");

--- a/plugin/src/main/code.ts
+++ b/plugin/src/main/code.ts
@@ -1472,53 +1472,12 @@ const handleRequest = async (request: ServerRequest): Promise<PluginResponse> =>
         const expectedLayerCount = countLayers(root);
 
         let layerCount = 0;
-        const textWeightFixes: Array<{ node: TextNode; weight: number }> = [];
         // html-figma renderer: walks the tree, creates frames/text/rects/SVG
-        // vectors, matches installed fonts, and resolves image fills.
-        await addLayersToFrame([root as never], wrapper, ({ node, layer }) => {
+        // vectors, matches installed fonts (including weights carried by the
+        // serialization), and resolves image fills.
+        await addLayersToFrame([root as never], wrapper, () => {
           layerCount += 1;
-          const weight = (layer as { fontWeight?: unknown }).fontWeight;
-          if (node.type === "TEXT" && typeof weight === "number" && weight >= 500) {
-            textWeightFixes.push({ node: node as TextNode, weight });
-          }
         });
-
-        // html-figma's font matcher only ever loads the Regular style, so
-        // restore heavier weights from the serialized numeric fontWeight.
-        // Families missing a style fall back one step lighter per candidate.
-        const styleCandidates = (weight: number): string[] => {
-          if (weight >= 900) return ["Black", "ExtraBold", "Bold"];
-          if (weight >= 800) return ["ExtraBold", "Bold"];
-          if (weight >= 700) return ["Bold", "SemiBold"];
-          if (weight >= 600) return ["SemiBold", "Bold", "Medium"];
-          return ["Medium", "SemiBold"];
-        };
-        for (const { node: textNode, weight } of textWeightFixes) {
-          const current = textNode.fontName;
-          if (current === figma.mixed) continue;
-          const beforeHeight = textNode.height;
-          for (const style of styleCandidates(weight)) {
-            try {
-              const fontName = { family: current.family, style };
-              await figma.loadFontAsync(fontName);
-              textNode.fontName = fontName;
-              break;
-            } catch {
-              // style not available in this family — try the next candidate
-            }
-          }
-          // The renderer width-adjusted this box with the Regular style; the
-          // heavier style is wider, so re-widen until the original line count
-          // (height) is restored.
-          let tries = 0;
-          while (textNode.height > beforeHeight && tries++ < 24) {
-            try {
-              textNode.resize(textNode.width + 1, textNode.height);
-            } catch {
-              break;
-            }
-          }
-        }
 
         return {
           type: request.type,

--- a/plugin/src/main/code.ts
+++ b/plugin/src/main/code.ts
@@ -1,4 +1,5 @@
 import { serializeNode } from "./serializer";
+import { addLayersToFrame } from "../html-figma/figma";
 
 type RequestType =
   | "get_document"
@@ -23,6 +24,7 @@ type RequestType =
   | "create_text"
   | "create_shape"
   | "create_image"
+  | "import_html_layers"
   | "duplicate_nodes"
   | "reparent_nodes"
   | "group_nodes"
@@ -341,6 +343,7 @@ const EDIT_REQUEST_TYPES = new Set<RequestType>([
   "create_text",
   "create_shape",
   "create_image",
+  "import_html_layers",
   "duplicate_nodes",
   "reparent_nodes",
   "group_nodes",
@@ -1426,6 +1429,115 @@ const handleRequest = async (request: ServerRequest): Promise<PluginResponse> =>
             width: node.width,
             height: node.height,
             imageHash: image.hash,
+          },
+        };
+      }
+      case "import_html_layers": {
+        const params = request.params ?? {};
+        const root = params.layers as
+          { type?: unknown; width?: unknown; height?: unknown } | undefined;
+        if (!root || typeof root !== "object" || typeof root.type !== "string") {
+          throw new Error(
+            "layers (an html-figma LayerNode tree) is required for import_html_layers"
+          );
+        }
+
+        const wrapper = figma.createFrame();
+        wrapper.name =
+          typeof params.name === "string" && params.name.length > 0
+            ? params.name
+            : "imported layers";
+        const rootWidth = typeof root.width === "number" ? root.width : 100;
+        const rootHeight = typeof root.height === "number" ? root.height : 100;
+        wrapper.resize(Math.max(rootWidth, 1), Math.max(rootHeight, 1));
+        wrapper.fills = [];
+        wrapper.clipsContent = true;
+        // Same contract as the create_* tools: when parentId is given the
+        // wrapper is appended into it and x/y are relative to that parent.
+        await appendToParentIfProvided(wrapper, params.parentId);
+        positionNode(wrapper, params.x, params.y);
+
+        // html-figma catches per-layer render errors internally and keeps
+        // going, so a failed layer would otherwise be silent. Count the tree
+        // up front and compare with how many layers actually rendered.
+        const countLayers = (layer: unknown): number => {
+          if (!layer || typeof layer !== "object") return 0;
+          const children = (layer as { children?: unknown }).children;
+          let total = 1;
+          if (Array.isArray(children)) {
+            for (const child of children) total += countLayers(child);
+          }
+          return total;
+        };
+        const expectedLayerCount = countLayers(root);
+
+        let layerCount = 0;
+        const textWeightFixes: Array<{ node: TextNode; weight: number }> = [];
+        // html-figma renderer: walks the tree, creates frames/text/rects/SVG
+        // vectors, matches installed fonts, and resolves image fills.
+        await addLayersToFrame([root as never], wrapper, ({ node, layer }) => {
+          layerCount += 1;
+          const weight = (layer as { fontWeight?: unknown }).fontWeight;
+          if (node.type === "TEXT" && typeof weight === "number" && weight >= 500) {
+            textWeightFixes.push({ node: node as TextNode, weight });
+          }
+        });
+
+        // html-figma's font matcher only ever loads the Regular style, so
+        // restore heavier weights from the serialized numeric fontWeight.
+        // Families missing a style fall back one step lighter per candidate.
+        const styleCandidates = (weight: number): string[] => {
+          if (weight >= 900) return ["Black", "ExtraBold", "Bold"];
+          if (weight >= 800) return ["ExtraBold", "Bold"];
+          if (weight >= 700) return ["Bold", "SemiBold"];
+          if (weight >= 600) return ["SemiBold", "Bold", "Medium"];
+          return ["Medium", "SemiBold"];
+        };
+        for (const { node: textNode, weight } of textWeightFixes) {
+          const current = textNode.fontName;
+          if (current === figma.mixed) continue;
+          const beforeHeight = textNode.height;
+          for (const style of styleCandidates(weight)) {
+            try {
+              const fontName = { family: current.family, style };
+              await figma.loadFontAsync(fontName);
+              textNode.fontName = fontName;
+              break;
+            } catch {
+              // style not available in this family — try the next candidate
+            }
+          }
+          // The renderer width-adjusted this box with the Regular style; the
+          // heavier style is wider, so re-widen until the original line count
+          // (height) is restored.
+          let tries = 0;
+          while (textNode.height > beforeHeight && tries++ < 24) {
+            try {
+              textNode.resize(textNode.width + 1, textNode.height);
+            } catch {
+              break;
+            }
+          }
+        }
+
+        return {
+          type: request.type,
+          requestId: request.requestId,
+          data: {
+            nodeId: wrapper.id,
+            nodeName: wrapper.name,
+            parentId: wrapper.parent?.id,
+            x: wrapper.x,
+            y: wrapper.y,
+            width: wrapper.width,
+            height: wrapper.height,
+            layerCount,
+            expectedLayerCount,
+            ...(layerCount < expectedLayerCount
+              ? {
+                  warning: `Partial import: ${expectedLayerCount - layerCount} of ${expectedLayerCount} layers failed to render (see the plugin console for per-layer errors). Delete node ${wrapper.id} and retry if completeness matters.`,
+                }
+              : {}),
           },
         };
       }

--- a/plugin/src/ui/App.tsx
+++ b/plugin/src/ui/App.tsx
@@ -51,7 +51,10 @@ type PluginStatus = {
   selectionCount: number;
 };
 
-const WS_BASE_URL = "ws://localhost:1994/ws";
+// `||` (not `??`) so an empty build-time value falls back to the default.
+// A custom endpoint must also be listed in manifest.json's
+// networkAccess.allowedDomains or Figma will block the connection.
+const WS_BASE_URL = import.meta.env.VITE_FIGMA_BRIDGE_WS || "ws://localhost:1994/ws";
 
 export default function App() {
   const [connected, setConnected] = useState(false);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -7,7 +7,23 @@ import { Election } from "./election.js";
 import { registerTools } from "./tools.js";
 import { VERSION } from "./version.js";
 
-const PORT = 1994;
+// Overridable so a fork/test instance can run beside a stock 1994 bridge
+// without joining its leader election. The plugin must be built with the
+// matching VITE_FIGMA_BRIDGE_WS URL (which must also be listed in the
+// plugin manifest's networkAccess.allowedDomains).
+function resolvePort(): number {
+  const raw = process.env.FIGMA_BRIDGE_PORT;
+  if (raw === undefined) return 1994;
+  const port = Number(raw.trim());
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    // An explicitly set but invalid value must not silently join the stock
+    // bridge on 1994 — fail loudly instead.
+    console.error(`Invalid FIGMA_BRIDGE_PORT "${raw}" — expected an integer between 1 and 65535`);
+    process.exit(1);
+  }
+  return port;
+}
+const PORT = resolvePort();
 
 async function main(): Promise<void> {
   const node = new Node(PORT);

--- a/server/src/schema.ts
+++ b/server/src/schema.ts
@@ -559,6 +559,37 @@ export const createImageInput = z.object({
   fileKey: fileKeyField,
 });
 
+/**
+ * A serialized layer tree produced by html-figma's browser `htmlToFigma()`.
+ * The tree is validated loosely here (root must at least carry a node type);
+ * the plugin-side renderer is the authority on the full shape.
+ */
+const htmlLayerTree = z
+  .object({ type: z.string().min(1) })
+  .passthrough()
+  .describe("Root LayerNode of an html-figma serialization");
+
+export const importHtmlLayersInput = z.object({
+  source: z
+    .string()
+    .min(1)
+    .describe(
+      "Path to a JSON file containing an html-figma htmlToFigma() layer tree, relative to the MCP server cwd (absolute paths must stay inside it)."
+    ),
+  name: z
+    .string()
+    .optional()
+    .describe("Optional name for the wrapper frame (default: 'imported layers')"),
+  parentId: createFigmaNodeIdSchema()
+    .optional()
+    .describe(
+      "Optional parent node ID (frame/section) to append the wrapper frame into. x/y become relative to that parent."
+    ),
+  x: z.number().optional().describe("Optional x position of the wrapper frame"),
+  y: z.number().optional().describe("Optional y position of the wrapper frame"),
+  fileKey: fileKeyField,
+});
+
 export const toolInputSchemas = {
   get_document: z.object({
     fileKey: fileKeyField,
@@ -691,6 +722,8 @@ export const toolInputSchemas = {
   create_shape: createShapeInput,
 
   create_image: createImageInput,
+
+  import_html_layers: importHtmlLayersInput,
 
   duplicate_nodes: z.object({
     nodeIds: z.array(createFigmaNodeIdSchema()).min(1).describe("List of node IDs to duplicate"),
@@ -852,9 +885,21 @@ const createImageRpcInput = createImageInput.omit({ source: true, fileKey: true 
  * payload before forwarding validate their wire shape here; every other tool
  * validates against its advertised MCP input schema.
  */
+/**
+ * Wire-format schema for import_html_layers on the follower→leader RPC path.
+ * Mirrors createImageRpcInput: the tool handler resolves `source` (JSON file
+ * path) into the parsed `layers` tree before forwarding.
+ */
+const importHtmlLayersRpcInput = importHtmlLayersInput
+  .omit({ source: true, fileKey: true })
+  .extend({
+    layers: htmlLayerTree,
+  });
+
 const rpcInputSchemas = {
   ...toolInputSchemas,
   create_image: createImageRpcInput,
+  import_html_layers: importHtmlLayersRpcInput,
 } as const;
 
 /**
@@ -897,6 +942,7 @@ const rpcToArgs: Record<
   create_text: (_nodeIds, params) => ({ ...params }),
   create_shape: (_nodeIds, params) => ({ ...params }),
   create_image: (_nodeIds, params) => ({ ...params }),
+  import_html_layers: (_nodeIds, params) => ({ ...params }),
   duplicate_nodes: (nodeIds, params) => ({ nodeIds, ...params }),
   reparent_nodes: (nodeIds, params) => ({ nodeIds, ...params }),
   group_nodes: (nodeIds, params) => ({ nodeIds, ...params }),
@@ -907,26 +953,11 @@ const rpcToArgs: Record<
   save_screenshots: (_nodeIds, params) => ({ ...params }),
   get_motion_styles: (_nodeIds, params) => ({ ...params }),
   get_node_motion: (nodeIds, params) => ({ ...params, nodeId: nodeIds?.[0] }),
-  apply_animation_style: (nodeIds, params) => ({
-    ...params,
-    nodeId: nodeIds?.[0],
-  }),
-  remove_animation_style: (nodeIds, params) => ({
-    ...params,
-    nodeId: nodeIds?.[0],
-  }),
-  apply_manual_keyframe_track: (nodeIds, params) => ({
-    ...params,
-    nodeId: nodeIds?.[0],
-  }),
-  remove_manual_keyframe_track: (nodeIds, params) => ({
-    ...params,
-    nodeId: nodeIds?.[0],
-  }),
-  set_timeline_duration: (nodeIds, params) => ({
-    ...params,
-    nodeId: nodeIds?.[0],
-  }),
+  apply_animation_style: (nodeIds, params) => ({ ...params, nodeId: nodeIds?.[0] }),
+  remove_animation_style: (nodeIds, params) => ({ ...params, nodeId: nodeIds?.[0] }),
+  apply_manual_keyframe_track: (nodeIds, params) => ({ ...params, nodeId: nodeIds?.[0] }),
+  remove_manual_keyframe_track: (nodeIds, params) => ({ ...params, nodeId: nodeIds?.[0] }),
+  set_timeline_duration: (nodeIds, params) => ({ ...params, nodeId: nodeIds?.[0] }),
 };
 
 /**

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { lookup } from "node:dns/promises";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, realpath, stat, writeFile } from "node:fs/promises";
 import { isIP } from "node:net";
 import path from "node:path";
 import type { z } from "zod";
@@ -9,6 +9,7 @@ import {
   createFrameInput,
   createImageInput,
   createPageInput,
+  importHtmlLayersInput,
   createShapeShape,
   createTextShape,
   createShapeInput,
@@ -388,6 +389,30 @@ export function registerTools(server: McpServer, node: Node, port: number): void
   );
 
   server.tool(
+    "import_html_layers",
+    "Import a DOM serialization (JSON produced by html-figma's browser htmlToFigma()) as editable Figma layers inside a new wrapper frame — frames, text, rectangles, and SVG vectors in one call. Source must be a JSON file path inside the MCP server working directory. Optionally append the wrapper into an existing frame/section via parentId. Requires the plugin to be open in the design editor. When multiple files are connected, specify fileKey.",
+    importHtmlLayersInput.shape,
+    async ({ source, fileKey, ...params }): Promise<ToolResult> => {
+      try {
+        const layers = await loadLayersJson(source, process.cwd());
+        return await renderResponse(() =>
+          node.sendWithParams("import_html_layers", undefined, { ...params, layers }, fileKey)
+        );
+      } catch (err) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: err instanceof Error ? err.message : String(err),
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.tool(
     "duplicate_nodes",
     "Duplicate one or more nodes in place. The duplicates remain under the same parent as the originals. When multiple files are connected, specify fileKey.",
     toolInputSchemas.duplicate_nodes.shape,
@@ -708,6 +733,62 @@ function resolveAndValidateOutputPath(outputPath: string, workspaceRoot: string)
  * @param workspaceRoot - Root directory for resolving relative local paths.
  * @returns Base64-encoded image bytes.
  */
+const MAX_LAYERS_JSON_BYTES = 16 * 1024 * 1024;
+
+/**
+ * Reads and parses an html-figma layer-tree JSON file from inside the
+ * workspace root. Mirrors the local-path rules of loadImageSourceAsBase64.
+ * @param source - JSON file path (absolute or relative to the workspace root).
+ * @param workspaceRoot - The MCP server working directory.
+ * @returns The parsed layer tree (root LayerNode).
+ */
+async function loadLayersJson(
+  source: string,
+  workspaceRoot: string
+): Promise<Record<string, unknown>> {
+  const resolvedRoot = await realpath(path.resolve(workspaceRoot));
+  const lexicalPath = path.resolve(resolvedRoot, source);
+  // Resolve symlinks before the containment check — a workspace-local symlink
+  // must not be able to point the read outside the working directory.
+  let resolvedPath: string;
+  try {
+    resolvedPath = await realpath(lexicalPath);
+  } catch {
+    throw new Error(`Layers source not found: ${source}`);
+  }
+  const relativePath = path.relative(resolvedRoot, resolvedPath);
+  const escapesRoot = relativePath.startsWith("..") || path.isAbsolute(relativePath);
+  if (escapesRoot) {
+    throw new Error(
+      `layers source must be inside the MCP server working directory: ${resolvedRoot}`
+    );
+  }
+  // Check the size before reading so an oversized file is rejected without
+  // allocating its contents.
+  const info = await stat(resolvedPath);
+  if (!info.isFile()) {
+    throw new Error(`Layers source is not a regular file: ${source}`);
+  }
+  if (info.size > MAX_LAYERS_JSON_BYTES) {
+    throw new Error(`Layers JSON exceeds ${MAX_LAYERS_JSON_BYTES} bytes`);
+  }
+  const bytes = await readFile(resolvedPath);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(bytes.toString("utf8"));
+  } catch {
+    throw new Error(`Layers source is not valid JSON: ${source}`);
+  }
+  // htmlToFigma() returns a single root LayerNode; tolerate a one-element array.
+  const root = Array.isArray(parsed) ? parsed[0] : parsed;
+  if (!root || typeof root !== "object" || typeof (root as { type?: unknown }).type !== "string") {
+    throw new Error(
+      "Layers JSON must be an html-figma LayerNode tree (object with a `type` field)"
+    );
+  }
+  return root as Record<string, unknown>;
+}
+
 async function loadImageSourceAsBase64(source: string, workspaceRoot: string): Promise<string> {
   if (/^https?:\/\//i.test(source)) {
     const bytes = await fetchImageBytes(source);


### PR DESCRIPTION
## What

Adds an `import_html_layers` tool that imports a DOM serialization — the JSON produced by [html-figma](https://github.com/sergcen/html-to-figma)'s browser `htmlToFigma()` — as **editable Figma layers in a single call**: frames, text, rectangles, and SVG vectors.

## Why

The existing `create_*` primitives are one MCP round-trip per node, which makes importing a whole screen (typically 500+ nodes from a real web page) impractical. With this tool the flow becomes: serialize the page in a browser (Playwright, extension, etc.) → write the JSON inside the MCP cwd → one `import_html_layers` call. In our testing a 1440×900 dashboard screen lands as 491 editable layers in a couple of seconds, with SVG icons as real vectors and installed fonts matched.

## How

- **server**: the tool reads a layer-tree JSON file from inside the MCP working directory (same path-containment rules and handler pattern as `create_image`), parses it, and forwards the tree. The follower→leader RPC wire schema mirrors `create_image`'s source→payload rewrite.
- **plugin**: renders the tree with html-figma's `addLayersToFrame` inside a wrapper frame. Guarded by the existing Dev Mode check (registered in `EDIT_REQUEST_TYPES`).
- **font weights**: html-figma's font matcher only ever loads the Regular style, which flattens headings/buttons. When a text layer carries a numeric `fontWeight`, the closest heavier style (Medium/SemiBold/Bold/ExtraBold/Black, with per-family fallback) is applied after rendering, and the text box is re-widened until its original line count is restored (the renderer width-adjusted it against Regular metrics). Layers without `fontWeight` are untouched, so trees from stock html-figma behave exactly as before.
- **dev convenience** (defaults unchanged): server port is overridable via `FIGMA_BRIDGE_PORT`, and the plugin WS URL via `VITE_FIGMA_BRIDGE_WS` at build time — lets a development instance run beside a stock 1994 bridge without joining its leader election.

## Notes for review

- New dependency: `html-figma@0.3.1` (plugin only). I couldn't regenerate `plugin/bun.lock` (my bun is pre-text-lockfile) — happy to update if you point me at the expected bun version, or feel free to regenerate on merge.
- Verified end-to-end against Figma desktop: 491-layer import, SVG vectors, Korean text with local font matching, weight restoration without re-wrapping.
- `import_html_layers` requires the design editor (Dev Mode rejects with the standard hint), and the JSON source must live inside the MCP cwd — both consistent with existing tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Import HTML layer trees into Figma as editable, styled layers.
  - Create and optionally activate named pages.
  - Position imported content within pages or frames.
  - Preserve text styling, fonts, images, colors, shadows, and opacity where supported.
  - Report imported layer counts and warn about partial rendering failures.

- **Bug Fixes**
  - Improved handling of nested page content and canvas drop positions.
  - Empty custom WebSocket settings now correctly fall back to the local connection.

- **Validation**
  - Added clearer validation for imported files, page settings, and bridge port configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->