### PR TITLE
feat(plugin): support collapsing the plugin window to a title bar

### DIFF
--- a/plugin/src/main/code.ts
+++ b/plugin/src/main/code.ts
@@ -1847,7 +1847,39 @@ const handleRequest = async (request: ServerRequest): Promise<PluginResponse> =>
   }
 };
 
-figma.showUI(__html__, { width: 320, height: 180 });
+const UI_WIDTH = 320;
+const UI_EXPANDED_HEIGHT = 180;
+/** Just the status bar: the collapsed ("minimized") window. */
+const UI_COLLAPSED_HEIGHT = 36;
+const UI_COLLAPSED_KEY = "ui-collapsed";
+
+let uiCollapsed = false;
+
+const applyUiSize = () => {
+  figma.ui.resize(UI_WIDTH, uiCollapsed ? UI_COLLAPSED_HEIGHT : UI_EXPANDED_HEIGHT);
+};
+
+const postUiCollapseState = () => {
+  figma.ui.postMessage({ type: "ui-collapse-state", payload: { collapsed: uiCollapsed } });
+};
+
+// Start hidden so the window never flashes at full height before the stored
+// collapsed state is restored. The iframe still loads and runs while hidden.
+figma.showUI(__html__, { width: UI_WIDTH, height: UI_EXPANDED_HEIGHT, visible: false });
+
+figma.clientStorage
+  .getAsync(UI_COLLAPSED_KEY)
+  .then((stored) => {
+    uiCollapsed = stored === true;
+  })
+  .catch(() => {
+    uiCollapsed = false;
+  })
+  .then(() => {
+    applyUiSize();
+    postUiCollapseState();
+    figma.ui.show();
+  });
 sendStatus();
 
 figma.on("selectionchange", () => {
@@ -1857,6 +1889,20 @@ figma.on("selectionchange", () => {
 figma.ui.onmessage = async (message) => {
   if (message.type === "ui-ready") {
     sendStatus();
+    return;
+  }
+
+  if (message.type === "request-ui-state") {
+    postUiCollapseState();
+    return;
+  }
+
+  if (message.type === "set-ui-collapsed") {
+    uiCollapsed = message.collapsed === true;
+    applyUiSize();
+    figma.clientStorage.setAsync(UI_COLLAPSED_KEY, uiCollapsed).catch(() => {
+      // Persisting the preference is best-effort; the window is already resized.
+    });
     return;
   }
 

--- a/plugin/src/ui/App.tsx
+++ b/plugin/src/ui/App.tsx
@@ -58,6 +58,7 @@ const WS_BASE_URL = import.meta.env.VITE_FIGMA_BRIDGE_WS || "ws://localhost:1994
 
 export default function App() {
   const [connected, setConnected] = useState(false);
+  const [collapsed, setCollapsed] = useState(false);
   const [status, setStatus] = useState<PluginStatus>({
     fileName: "Unknown file",
     fileKey: "",
@@ -71,6 +72,15 @@ export default function App() {
     [connected]
   );
 
+  // One definition, rendered either in the collapsed bar or in the footer --
+  // never both at once, since .body is hidden while collapsed.
+  const statusBadge = (
+    <div className={`badge ${connected ? "connected" : "disconnected"}`}>
+      <span className="dot" />
+      <span className="badge-text">{statusLabel}</span>
+    </div>
+  );
+
   useEffect(() => {
     const handleMessage = (event: MessageEvent) => {
       const msg = event.data?.pluginMessage;
@@ -78,6 +88,11 @@ export default function App() {
 
       if (msg.type === "plugin-status") {
         setStatus(msg.payload);
+        return;
+      }
+
+      if (msg.type === "ui-collapse-state") {
+        setCollapsed(msg.payload?.collapsed === true);
         return;
       }
 
@@ -92,10 +107,21 @@ export default function App() {
     };
 
     window.addEventListener("message", handleMessage);
+    // The main thread reads the persisted state asynchronously, so ask for it
+    // on mount rather than relying on a broadcast we may have missed.
+    parent.postMessage({ pluginMessage: { type: "request-ui-state" } }, "*");
     return () => {
       window.removeEventListener("message", handleMessage);
     };
   }, []);
+
+  const toggleCollapsed = () => {
+    setCollapsed((previous) => {
+      const next = !previous;
+      parent.postMessage({ pluginMessage: { type: "set-ui-collapsed", collapsed: next } }, "*");
+      return next;
+    });
+  };
 
   // Connect/reconnect WebSocket when fileKey changes
   useEffect(() => {
@@ -168,38 +194,59 @@ export default function App() {
   }, [status.fileKey, status.fileName]);
 
   return (
-    <div className="container">
-      <div className="info-section">
-        <div className="info-row">
-          <span className="info-label">File:</span>
-          <span className="info-value">{status.fileName}</span>
-        </div>
-        <div className="info-row">
-          <span className="info-label">Selection:</span>
-          <span className="info-value">{status.selectionCount} node(s)</span>
-        </div>
-      </div>
+    <div className={`container ${collapsed ? "collapsed" : ""}`}>
+      {collapsed && <div className="titlebar">{statusBadge}</div>}
 
-      <div className="footer">
-        <div className={`badge ${connected ? "connected" : "disconnected"}`}>
-          <span className="dot" />
-          <span className="badge-text">{statusLabel}</span>
+      <button
+        type="button"
+        className="collapse-toggle"
+        onClick={toggleCollapsed}
+        title={collapsed ? "Restore" : "Minimize"}
+        aria-label={collapsed ? "Restore" : "Minimize"}
+        aria-expanded={!collapsed}
+      >
+        <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true">
+          <path
+            d="M1 3.5 L5 7 L9 3.5"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </button>
+
+      <div className="body">
+        <div className="info-section">
+          <div className="info-row">
+            <span className="info-label">File:</span>
+            <span className="info-value">{status.fileName}</span>
+          </div>
+          <div className="info-row">
+            <span className="info-label">Selection:</span>
+            <span className="info-value">{status.selectionCount} node(s)</span>
+          </div>
         </div>
-        <a
-          href="https://www.gethopp.app/?ref=figma-mcp-bridge"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="branding"
-        >
-          <img src={hoppLogo} alt="Hopp" className="logo" />
-          <span className="sponsored-text">
-            Sponsored by Hopp
-            <br />
-            The best open-source
-            <br />
-            pair-programming app
-          </span>
-        </a>
+
+        <div className="footer">
+          {statusBadge}
+          <a
+            href="https://www.gethopp.app/?ref=figma-mcp-bridge"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="branding"
+          >
+            <img src={hoppLogo} alt="Hopp" className="logo" />
+            <span className="sponsored-text">
+              Sponsored by Hopp
+              <br />
+              The best open-source
+              <br />
+              pair-programming app
+            </span>
+          </a>
+        </div>
       </div>
     </div>
   );

--- a/plugin/src/ui/index.css
+++ b/plugin/src/ui/index.css
@@ -8,6 +8,7 @@
   --dot-connected: #17b26a;
   --dot-disconnected: #f04438;
   --text-white: #ffffff;
+  --toggle-hover: rgba(255, 255, 255, 0.1);
 }
 
 * {
@@ -28,17 +29,71 @@ body {
 }
 
 .container {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
+}
+
+.titlebar {
+  display: flex;
+  align-items: center;
+  height: 36px;
+  flex-shrink: 0;
+  padding: 0 38px 0 14px;
+}
+
+.collapse-toggle {
+  position: absolute;
+  top: 7px;
+  right: 8px;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-label);
+  cursor: pointer;
+}
+
+.collapse-toggle:hover {
+  background: var(--toggle-hover);
+  color: var(--text-value);
+}
+
+.collapse-toggle svg {
+  transition: transform 120ms ease;
+}
+
+.container.collapsed .collapse-toggle svg {
+  transform: rotate(180deg);
+}
+
+.body {
+  flex: 1;
+  min-height: 0;
   padding: 14px;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  height: 100vh;
+}
+
+.container.collapsed .body {
+  display: none;
 }
 
 .info-section {
   display: flex;
   flex-direction: column;
   gap: 10px;
+  /* Keeps a long file name clear of the floating toggle. */
+  padding-right: 26px;
 }
 
 .info-row {


### PR DESCRIPTION
Because the plugin window must remain open to keep the WebSocket alive, a chevron is added in the top-right corner that collapses the window into a 36px title bar, minimizing how much it blocks the content underneath.

- Collapsed bar displays the connection badge.
- The toggle is absolutely positioned, so the expanded layout gives up no height for it — the expanded window remains 180px, the same as before.
- Uses `figma.ui.resize` for collapse/restore.
- Persists collapse state in `figma.clientStorage` under `"ui-collapsed"`.

The video below shows the behavior after this commit.

https://github.com/user-attachments/assets/1145b60b-977b-4488-b171-53279f5b62d2



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a collapsible plugin panel with expanded and compact views.
  * Added a toggle control with visual state indication.
  * The panel remembers its collapsed or expanded state between sessions.
  * Status information remains visible in the compact view.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->